### PR TITLE
phase1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.env
+log/*
+
+!log/slow.log
+!log/slow-report.txt

--- a/apply-tuning.sh
+++ b/apply-tuning.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+source .env
+
+echo "==> Applying tuning SQL from $SQL_FILE to MySQL container $CONTAINER_NAME ..."
+
+docker exec -i $CONTAINER_NAME mysql -u root -p$MYSQL_PASSWORD $DATABASE_NAME < $SQL_FILE
+
+echo "==> Done."

--- a/log/slow-report.txt
+++ b/log/slow-report.txt
@@ -1,0 +1,83 @@
+
+# 320ms user time, 10ms system time, 29.02M rss, 32.00M vsz
+# Current date: Sun Jun  8 06:28:01 2025
+# Hostname: DESKTOP-J12AL4D
+# Files: ./log/slow.log
+# Overall: 2.28k total, 11 unique, 27.15 QPS, 0.91x concurrency __________
+# Time range: 2025-06-07T20:25:48 to 2025-06-07T20:27:12
+# Attribute          total     min     max     avg     95%  stddev  median
+# ============     ======= ======= ======= ======= ======= ======= =======
+# Exec time            76s     2ms    77ms    33ms    53ms    16ms    21ms
+# Lock time            4ms       0    44us     1us     2us     1us     1us
+# Rows sent        443.79k       0   9.77k  199.23    2.90   1.30k    0.99
+# Rows examine     212.20M    1000  97.67k  95.26k  97.04k  13.74k  97.04k
+# Query size       165.04k      28     136   74.09   80.10    9.76   80.10
+
+# Profile
+# Rank Query ID                       Response time Calls R/Call V/M   Ite
+# ==== ============================== ============= ===== ====== ===== ===
+#    1 0x624863D30DAC59FA168492821... 54.5765 71.5%  1085 0.0503  0.00 SELECT comments
+#    2 0x422390B42D4DD86C7539A5F45... 19.5732 25.6%  1097 0.0178  0.00 SELECT comments
+# MISC 0xMISC                          2.2205  2.9%    99 0.0224   0.0 <9 ITEMS>
+
+# Query 1: 13.07 QPS, 0.66x concurrency, ID 0x624863D30DAC59FA16849282195BE09F at byte 283524
+# This item is included in the report because it matches --limit.
+# Scores: V/M = 0.00
+# Time range: 2025-06-07T20:25:49 to 2025-06-07T20:27:12
+# Attribute    pct   total     min     max     avg     95%  stddev  median
+# ============ === ======= ======= ======= ======= ======= ======= =======
+# Count         47    1085
+# Exec time     71     55s    43ms    70ms    50ms    56ms     4ms    48ms
+# Lock time     57     2ms     1us    44us     1us     2us     1us     1us
+# Rows sent      0   2.94k       0       3    2.77    2.90    0.77    2.90
+# Rows examine  48 103.48M  97.66k  97.67k  97.66k  97.04k       0  97.04k
+# Query size    52  87.00k      81      83   82.11   80.10       0   80.10
+# String:
+# Databases    isuconp
+# Hosts        172.20.0.4
+# Users        root
+# Query_time distribution
+#   1us
+#  10us
+# 100us
+#   1ms
+#  10ms  ################################################################
+# 100ms
+#    1s
+#  10s+
+# Tables
+#    SHOW TABLE STATUS FROM `isuconp` LIKE 'comments'\G
+#    SHOW CREATE TABLE `isuconp`.`comments`\G
+# EXPLAIN /*!50100 PARTITIONS*/
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3\G
+
+# Query 2: 13.22 QPS, 0.24x concurrency, ID 0x422390B42D4DD86C7539A5F45EB76A80 at byte 944
+# This item is included in the report because it matches --limit.
+# Scores: V/M = 0.00
+# Time range: 2025-06-07T20:25:49 to 2025-06-07T20:27:12
+# Attribute    pct   total     min     max     avg     95%  stddev  median
+# ============ === ======= ======= ======= ======= ======= ======= =======
+# Count         48    1097
+# Exec time     25     20s    15ms    71ms    18ms    20ms     3ms    17ms
+# Lock time     35     1ms       0    34us     1us     2us     1us     1us
+# Rows sent      0   1.07k       1       1       1       1       0       1
+# Rows examine  49 104.62M  97.66k  97.66k  97.66k  97.04k       0  97.04k
+# Query size    42  69.75k      64      66   65.11   65.89       1   62.76
+# String:
+# Databases    isuconp
+# Hosts        172.20.0.4
+# Users        root
+# Query_time distribution
+#   1us
+#  10us
+# 100us
+#   1ms
+#  10ms  ################################################################
+# 100ms
+#    1s
+#  10s+
+# Tables
+#    SHOW TABLE STATUS FROM `isuconp` LIKE 'comments'\G
+#    SHOW CREATE TABLE `isuconp`.`comments`\G
+# EXPLAIN /*!50100 PARTITIONS*/
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10000\G

--- a/log/slow.log
+++ b/log/slow.log
@@ -1,0 +1,11409 @@
+/usr/sbin/mysqld, Version: 8.4.5 (MySQL Community Server - GPL). started with:
+Tcp port: 3306  Unix socket: /var/run/mysqld/mysqld.sock
+Time                 Id Command    Argument
+# Time: 2025-06-07T20:25:48.306041Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.011583  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 1000
+use isuconp;
+SET timestamp=1749327948;
+UPDATE users SET del_flg = 0;
+# Time: 2025-06-07T20:25:48.315094Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.008071  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 1000
+SET timestamp=1749327948;
+UPDATE users SET del_flg = 1 WHERE id % 50 = 0;
+# Time: 2025-06-07T20:25:48.974738Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.033807  Lock_time: 0.000003 Rows_sent: 10000  Rows_examined: 20000
+SET timestamp=1749327948;
+SELECT `id`, `user_id`, `body`, `created_at`, `mime` FROM `posts` ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:25:49.193257Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.071327  Lock_time: 0.000003 Rows_sent: 1  Rows_examined: 100000
+SET timestamp=1749327949;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10000;
+# Time: 2025-06-07T20:25:49.240935Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.046783  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100003
+SET timestamp=1749327949;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:49.260972Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016188  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100000
+SET timestamp=1749327949;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9999;
+# Time: 2025-06-07T20:25:49.308435Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.046738  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100003
+SET timestamp=1749327949;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:49.327673Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016111  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100000
+SET timestamp=1749327949;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9998;
+# Time: 2025-06-07T20:25:49.376022Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.047680  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100003
+SET timestamp=1749327949;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:49.395066Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015460  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100000
+SET timestamp=1749327949;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9997;
+# Time: 2025-06-07T20:25:49.439575Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043908  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100003
+SET timestamp=1749327949;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:49.459082Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015750  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100000
+SET timestamp=1749327949;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9996;
+# Time: 2025-06-07T20:25:49.505637Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.045985  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100003
+SET timestamp=1749327949;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:49.524097Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015883  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100000
+SET timestamp=1749327949;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9995;
+# Time: 2025-06-07T20:25:49.571846Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.047164  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100003
+SET timestamp=1749327949;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:49.590904Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015840  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100000
+SET timestamp=1749327949;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9994;
+# Time: 2025-06-07T20:25:49.636446Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044949  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100003
+SET timestamp=1749327949;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:49.656422Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016464  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100000
+SET timestamp=1749327949;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9993;
+# Time: 2025-06-07T20:25:49.702300Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.045346  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100003
+SET timestamp=1749327949;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:49.722195Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015967  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100000
+SET timestamp=1749327949;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9992;
+# Time: 2025-06-07T20:25:49.773358Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050577  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100003
+SET timestamp=1749327949;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:49.794786Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018611  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100000
+SET timestamp=1749327949;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9991;
+# Time: 2025-06-07T20:25:49.841942Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.046365  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100003
+SET timestamp=1749327949;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:49.860931Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015691  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100000
+SET timestamp=1749327949;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9990;
+# Time: 2025-06-07T20:25:49.905487Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043947  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100003
+SET timestamp=1749327949;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:49.924064Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015719  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100000
+SET timestamp=1749327949;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9989;
+# Time: 2025-06-07T20:25:49.969355Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044566  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100003
+SET timestamp=1749327949;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:49.988919Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015766  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100000
+SET timestamp=1749327949;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9988;
+# Time: 2025-06-07T20:25:50.036192Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.046807  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100003
+SET timestamp=1749327949;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:50.057306Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017251  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100000
+SET timestamp=1749327950;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9987;
+# Time: 2025-06-07T20:25:50.110213Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052283  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100003
+SET timestamp=1749327950;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:50.154169Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015433  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100000
+SET timestamp=1749327950;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9986;
+# Time: 2025-06-07T20:25:50.198430Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043845  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100003
+SET timestamp=1749327950;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:50.216551Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015316  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100000
+SET timestamp=1749327950;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9985;
+# Time: 2025-06-07T20:25:50.261359Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043384  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100003
+SET timestamp=1749327950;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:50.279069Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015293  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100000
+SET timestamp=1749327950;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9984;
+# Time: 2025-06-07T20:25:50.322938Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043464  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100003
+SET timestamp=1749327950;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:50.340423Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015280  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100000
+SET timestamp=1749327950;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9983;
+# Time: 2025-06-07T20:25:50.385300Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044497  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100003
+SET timestamp=1749327950;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:50.402904Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015270  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100000
+SET timestamp=1749327950;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9982;
+# Time: 2025-06-07T20:25:50.447059Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043719  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100003
+SET timestamp=1749327950;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:50.465601Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016004  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100000
+SET timestamp=1749327950;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9981;
+# Time: 2025-06-07T20:25:50.510312Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044052  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100003
+SET timestamp=1749327950;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:50.529360Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016017  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100000
+SET timestamp=1749327950;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9980;
+# Time: 2025-06-07T20:25:50.573108Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043195  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100003
+SET timestamp=1749327950;
+SELECT * FROM `comments` WHERE `post_id` = 9980 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:50.591844Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015711  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100000
+SET timestamp=1749327950;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9979;
+# Time: 2025-06-07T20:25:50.635774Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043515  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100003
+SET timestamp=1749327950;
+SELECT * FROM `comments` WHERE `post_id` = 9979 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:50.669766Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.004784  Lock_time: 0.000001 Rows_sent: 11  Rows_examined: 10011
+SET timestamp=1749327950;
+SELECT `id`, `user_id`, `body`, `mime`, `created_at` FROM `posts` WHERE `user_id` = 881 ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:25:50.685725Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015557  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100000
+SET timestamp=1749327950;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9861;
+# Time: 2025-06-07T20:25:50.730100Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043837  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100003
+SET timestamp=1749327950;
+SELECT * FROM `comments` WHERE `post_id` = 9861 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:50.748064Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015471  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100000
+SET timestamp=1749327950;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 8577;
+# Time: 2025-06-07T20:25:50.791989Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043529  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100003
+SET timestamp=1749327950;
+SELECT * FROM `comments` WHERE `post_id` = 8577 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:50.810161Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015580  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100000
+SET timestamp=1749327950;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 8402;
+# Time: 2025-06-07T20:25:50.854155Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043612  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100003
+SET timestamp=1749327950;
+SELECT * FROM `comments` WHERE `post_id` = 8402 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:50.872395Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015649  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100000
+SET timestamp=1749327950;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 8166;
+# Time: 2025-06-07T20:25:50.917319Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044446  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100003
+SET timestamp=1749327950;
+SELECT * FROM `comments` WHERE `post_id` = 8166 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:50.935522Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015612  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100000
+SET timestamp=1749327950;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 7824;
+# Time: 2025-06-07T20:25:50.980514Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044603  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100003
+SET timestamp=1749327950;
+SELECT * FROM `comments` WHERE `post_id` = 7824 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:50.999569Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016492  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100000
+SET timestamp=1749327950;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 6287;
+# Time: 2025-06-07T20:25:51.042692Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.042651  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100003
+SET timestamp=1749327951;
+SELECT * FROM `comments` WHERE `post_id` = 6287 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:51.061323Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015933  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100000
+SET timestamp=1749327951;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 5988;
+# Time: 2025-06-07T20:25:51.108597Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.046812  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100003
+SET timestamp=1749327951;
+SELECT * FROM `comments` WHERE `post_id` = 5988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:51.126831Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015756  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100000
+SET timestamp=1749327951;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 5285;
+# Time: 2025-06-07T20:25:51.171045Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043770  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100003
+SET timestamp=1749327951;
+SELECT * FROM `comments` WHERE `post_id` = 5285 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:51.189736Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015681  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100000
+SET timestamp=1749327951;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 3623;
+# Time: 2025-06-07T20:25:51.234390Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044208  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100003
+SET timestamp=1749327951;
+SELECT * FROM `comments` WHERE `post_id` = 3623 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:51.253012Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015850  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100000
+SET timestamp=1749327951;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 2506;
+# Time: 2025-06-07T20:25:51.296961Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043545  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100003
+SET timestamp=1749327951;
+SELECT * FROM `comments` WHERE `post_id` = 2506 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:51.315215Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015684  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100000
+SET timestamp=1749327951;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 1985;
+# Time: 2025-06-07T20:25:51.358798Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043212  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100003
+SET timestamp=1749327951;
+SELECT * FROM `comments` WHERE `post_id` = 1985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:51.377120Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015556  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100000
+SET timestamp=1749327951;
+SELECT COUNT(*) AS count FROM `comments` WHERE `user_id` = 881;
+# Time: 2025-06-07T20:25:51.379325Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.001812  Lock_time: 0.000002 Rows_sent: 11  Rows_examined: 10000
+SET timestamp=1749327951;
+SELECT `id` FROM `posts` WHERE `user_id` = 881;
+# Time: 2025-06-07T20:25:51.397669Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017689  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100000
+SET timestamp=1749327951;
+SELECT COUNT(*) AS count FROM `comments` WHERE `post_id` IN (1985,2506,3623,5285,5988,6287,7824,8166,8402,8577,9861);
+# Time: 2025-06-07T20:25:51.443261Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016189  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327951;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9861;
+# Time: 2025-06-07T20:25:51.489583Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.045856  Lock_time: 0.000002 Rows_sent: 6  Rows_examined: 100007
+SET timestamp=1749327951;
+SELECT * FROM `comments` WHERE `post_id` = 9861 ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:25:51.537966Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.014399  Lock_time: 0.000001 Rows_sent: 10000  Rows_examined: 20000
+SET timestamp=1749327951;
+SELECT `id`, `user_id`, `body`, `created_at`, `mime` FROM `posts` ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:25:51.585274Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015575  Lock_time: 0.000003 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327951;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10000;
+# Time: 2025-06-07T20:25:51.630599Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044943  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327951;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:51.648111Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015398  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327951;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9999;
+# Time: 2025-06-07T20:25:51.692278Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043704  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327951;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:51.709356Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.014961  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327951;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9998;
+# Time: 2025-06-07T20:25:51.753568Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043884  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327951;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:51.771035Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015303  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327951;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9997;
+# Time: 2025-06-07T20:25:51.814711Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043332  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327951;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:51.832770Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015173  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327951;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9996;
+# Time: 2025-06-07T20:25:51.876391Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043270  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327951;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:51.894958Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016368  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327951;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9995;
+# Time: 2025-06-07T20:25:51.938236Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.042848  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327951;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:51.955451Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015122  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327951;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9994;
+# Time: 2025-06-07T20:25:52.000224Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044364  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327951;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:52.018008Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015628  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327952;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9993;
+# Time: 2025-06-07T20:25:52.062156Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043723  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327952;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:52.079727Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015266  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327952;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9992;
+# Time: 2025-06-07T20:25:52.128249Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.048103  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327952;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:52.147839Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017021  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327952;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9991;
+# Time: 2025-06-07T20:25:52.194412Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.045969  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327952;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:52.212849Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015614  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327952;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9990;
+# Time: 2025-06-07T20:25:52.257351Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043944  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327952;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:52.274866Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015107  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327952;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9989;
+# Time: 2025-06-07T20:25:52.321058Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.045758  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327952;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:52.338704Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015456  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327952;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9988;
+# Time: 2025-06-07T20:25:52.382291Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043030  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327952;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:52.402468Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015149  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327952;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9987;
+# Time: 2025-06-07T20:25:52.445816Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043001  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327952;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:52.462975Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015055  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327952;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9986;
+# Time: 2025-06-07T20:25:52.507212Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043874  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327952;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:52.524981Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015521  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327952;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9985;
+# Time: 2025-06-07T20:25:52.577270Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051766  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327952;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:52.597193Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017477  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327952;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9984;
+# Time: 2025-06-07T20:25:52.643167Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.045453  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327952;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:52.660590Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015311  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327952;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9983;
+# Time: 2025-06-07T20:25:52.704871Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043919  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327952;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:52.722701Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015686  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327952;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9982;
+# Time: 2025-06-07T20:25:52.767991Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044882  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327952;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:52.785726Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015628  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327952;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9981;
+# Time: 2025-06-07T20:25:52.830800Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044651  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327952;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:52.848487Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015426  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327952;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9980;
+# Time: 2025-06-07T20:25:52.892528Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043592  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327952;
+SELECT * FROM `comments` WHERE `post_id` = 9980 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:52.910873Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016133  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327952;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9979;
+# Time: 2025-06-07T20:25:52.955185Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043815  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327952;
+SELECT * FROM `comments` WHERE `post_id` = 9979 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:53.022270Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016645  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327953;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10023;
+# Time: 2025-06-07T20:25:53.067139Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044415  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1749327953;
+SELECT * FROM `comments` WHERE `post_id` = 10023 ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:25:53.162752Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016160  Lock_time: 0.000001 Rows_sent: 10001  Rows_examined: 20002
+SET timestamp=1749327953;
+SELECT `id`, `user_id`, `body`, `created_at`, `mime` FROM `posts` ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:25:53.207094Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015859  Lock_time: 0.000003 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327953;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10023;
+# Time: 2025-06-07T20:25:53.251967Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044354  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1749327953;
+SELECT * FROM `comments` WHERE `post_id` = 10023 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:53.268406Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015322  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327953;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10000;
+# Time: 2025-06-07T20:25:53.312486Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043587  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327953;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:53.330625Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015451  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327953;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9999;
+# Time: 2025-06-07T20:25:53.374999Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043887  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327953;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:53.393094Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015435  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327953;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9998;
+# Time: 2025-06-07T20:25:53.436637Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043133  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327953;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:53.454373Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015592  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327953;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9997;
+# Time: 2025-06-07T20:25:53.497965Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043176  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327953;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:53.516187Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016190  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327953;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9996;
+# Time: 2025-06-07T20:25:53.559708Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043065  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327953;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:53.577091Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015198  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327953;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9995;
+# Time: 2025-06-07T20:25:53.621710Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044248  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327953;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:53.639470Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015466  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327953;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9994;
+# Time: 2025-06-07T20:25:53.683418Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043530  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327953;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:53.701490Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015539  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327953;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9993;
+# Time: 2025-06-07T20:25:53.746762Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044782  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327953;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:53.765230Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015783  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327953;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9992;
+# Time: 2025-06-07T20:25:53.809397Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043532  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327953;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:53.827035Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015226  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327953;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9991;
+# Time: 2025-06-07T20:25:53.871271Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043845  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327953;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:53.890485Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016999  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327953;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9990;
+# Time: 2025-06-07T20:25:53.936178Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.045126  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327953;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:53.955417Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015184  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327953;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9989;
+# Time: 2025-06-07T20:25:53.999399Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043411  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327953;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:54.017817Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015805  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327954;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9988;
+# Time: 2025-06-07T20:25:54.061887Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043562  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327954;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:54.080356Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015847  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327954;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9987;
+# Time: 2025-06-07T20:25:54.126401Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.045576  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327954;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:54.143983Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015172  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327954;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9986;
+# Time: 2025-06-07T20:25:54.191261Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.046876  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327954;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:54.211054Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017324  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327954;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9985;
+# Time: 2025-06-07T20:25:54.262083Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050469  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327954;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:54.281149Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015894  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327954;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9984;
+# Time: 2025-06-07T20:25:54.325238Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043461  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327954;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:54.343718Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015286  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327954;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9983;
+# Time: 2025-06-07T20:25:54.387271Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.042999  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327954;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:54.404911Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015228  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327954;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9982;
+# Time: 2025-06-07T20:25:54.448414Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043130  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327954;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:54.465976Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015145  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327954;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9981;
+# Time: 2025-06-07T20:25:54.509197Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.042842  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327954;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:54.528035Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016392  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327954;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9980;
+# Time: 2025-06-07T20:25:54.572875Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044347  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327954;
+SELECT * FROM `comments` WHERE `post_id` = 9980 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:54.626283Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.014100  Lock_time: 0.000001 Rows_sent: 10001  Rows_examined: 20002
+SET timestamp=1749327954;
+SELECT `id`, `user_id`, `body`, `created_at`, `mime` FROM `posts` ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:25:54.665810Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015884  Lock_time: 0.000003 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327954;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10023;
+# Time: 2025-06-07T20:25:54.709868Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043569  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1749327954;
+SELECT * FROM `comments` WHERE `post_id` = 10023 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:54.726375Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015405  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327954;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10000;
+# Time: 2025-06-07T20:25:54.771708Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044851  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327954;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:54.790895Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016697  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327954;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9999;
+# Time: 2025-06-07T20:25:54.834903Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043492  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327954;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:54.852155Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015038  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327954;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9998;
+# Time: 2025-06-07T20:25:54.897828Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.045105  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327954;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:54.915486Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015039  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327954;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9997;
+# Time: 2025-06-07T20:25:54.959315Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043334  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327954;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:54.976696Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015400  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327954;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9996;
+# Time: 2025-06-07T20:25:55.021166Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044114  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327954;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:55.038722Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015517  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327955;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9995;
+# Time: 2025-06-07T20:25:55.083061Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043918  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327955;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:55.100956Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015795  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327955;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9994;
+# Time: 2025-06-07T20:25:55.144505Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043084  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327955;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:55.161550Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015012  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327955;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9993;
+# Time: 2025-06-07T20:25:55.205561Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043646  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327955;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:55.222709Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015059  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327955;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9992;
+# Time: 2025-06-07T20:25:55.267153Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044047  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327955;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:55.284829Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015611  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327955;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9991;
+# Time: 2025-06-07T20:25:55.329945Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044656  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327955;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:55.349797Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016820  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327955;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9990;
+# Time: 2025-06-07T20:25:55.398948Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.048631  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327955;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:55.417908Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016155  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327955;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9989;
+# Time: 2025-06-07T20:25:55.462787Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044277  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327955;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:55.480785Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015416  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327955;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9988;
+# Time: 2025-06-07T20:25:55.524675Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043395  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327955;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:55.542025Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015380  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327955;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9987;
+# Time: 2025-06-07T20:25:55.586960Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044465  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327955;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:55.604206Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015233  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327955;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9986;
+# Time: 2025-06-07T20:25:55.648968Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044407  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327955;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:55.666223Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015148  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327955;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9985;
+# Time: 2025-06-07T20:25:55.709614Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043017  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327955;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:55.726883Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015131  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327955;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9984;
+# Time: 2025-06-07T20:25:55.769845Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.042564  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327955;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:55.787140Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015026  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327955;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9983;
+# Time: 2025-06-07T20:25:55.833679Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.046116  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327955;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:55.854348Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015608  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327955;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9982;
+# Time: 2025-06-07T20:25:55.899109Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044237  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327955;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:55.917331Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016014  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327955;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9981;
+# Time: 2025-06-07T20:25:55.960908Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043121  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327955;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:55.978013Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015064  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327955;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9980;
+# Time: 2025-06-07T20:25:56.022880Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044491  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327955;
+SELECT * FROM `comments` WHERE `post_id` = 9980 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:56.085509Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015140  Lock_time: 0.000001 Rows_sent: 10001  Rows_examined: 20002
+SET timestamp=1749327956;
+SELECT `id`, `user_id`, `body`, `created_at`, `mime` FROM `posts` ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:25:56.126345Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015396  Lock_time: 0.000003 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327956;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10023;
+# Time: 2025-06-07T20:25:56.170480Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043554  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1749327956;
+SELECT * FROM `comments` WHERE `post_id` = 10023 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:56.187499Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015645  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327956;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10000;
+# Time: 2025-06-07T20:25:56.231000Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.042933  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327956;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:56.250810Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016583  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327956;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9999;
+# Time: 2025-06-07T20:25:56.300244Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049027  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327956;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:56.319855Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016978  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327956;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9998;
+# Time: 2025-06-07T20:25:56.365191Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044786  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327956;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:56.382871Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015143  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327956;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9997;
+# Time: 2025-06-07T20:25:56.427218Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043947  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327956;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:56.444763Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015081  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327956;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9996;
+# Time: 2025-06-07T20:25:56.488254Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043100  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327956;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:56.505890Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015174  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327956;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9995;
+# Time: 2025-06-07T20:25:56.549027Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.042743  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327956;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:56.567220Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015640  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327956;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9994;
+# Time: 2025-06-07T20:25:56.611534Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043826  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327956;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:56.629752Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015586  Lock_time: 0.000020 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327956;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9993;
+# Time: 2025-06-07T20:25:56.673824Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043679  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327956;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:56.691519Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015264  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327956;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9992;
+# Time: 2025-06-07T20:25:56.735012Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043084  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327956;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:56.752316Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.014946  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327956;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9991;
+# Time: 2025-06-07T20:25:56.797684Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044974  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327956;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:56.815863Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015643  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327956;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9990;
+# Time: 2025-06-07T20:25:56.860172Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043781  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327956;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:56.878512Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015152  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327956;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9989;
+# Time: 2025-06-07T20:25:56.922571Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043487  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327956;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:56.941393Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015748  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327956;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9988;
+# Time: 2025-06-07T20:25:56.985392Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043322  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327956;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:57.004215Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015595  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327956;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9987;
+# Time: 2025-06-07T20:25:57.048152Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043242  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327957;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:57.066672Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015348  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327957;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9986;
+# Time: 2025-06-07T20:25:57.111523Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044247  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327957;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:57.129740Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015020  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327957;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9985;
+# Time: 2025-06-07T20:25:57.173624Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043334  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327957;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:57.194163Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015275  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327957;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9984;
+# Time: 2025-06-07T20:25:57.238046Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043407  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327957;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:57.256319Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015547  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327957;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9983;
+# Time: 2025-06-07T20:25:57.299923Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043030  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327957;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:57.317032Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015044  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327957;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9982;
+# Time: 2025-06-07T20:25:57.361030Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043651  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327957;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:57.378219Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015150  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327957;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9981;
+# Time: 2025-06-07T20:25:57.423050Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044448  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327957;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:57.440362Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015243  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327957;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9980;
+# Time: 2025-06-07T20:25:57.484379Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043617  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327957;
+SELECT * FROM `comments` WHERE `post_id` = 9980 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:57.828476Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015478  Lock_time: 0.000003 Rows_sent: 10001  Rows_examined: 20002
+SET timestamp=1749327957;
+SELECT `id`, `user_id`, `body`, `created_at`, `mime` FROM `posts` ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:25:57.869740Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016636  Lock_time: 0.000003 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327957;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10023;
+# Time: 2025-06-07T20:25:57.917129Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.047013  Lock_time: 0.000001 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1749327957;
+SELECT * FROM `comments` WHERE `post_id` = 10023 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:57.934565Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016481  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327957;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10000;
+# Time: 2025-06-07T20:25:57.982112Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.047097  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327957;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:58.000789Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016736  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327957;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9999;
+# Time: 2025-06-07T20:25:58.045716Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044393  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327958;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:58.063397Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015288  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327958;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9998;
+# Time: 2025-06-07T20:25:58.107637Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043776  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327958;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:58.127332Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017445  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327958;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9997;
+# Time: 2025-06-07T20:25:58.175879Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.048006  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327958;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:58.196816Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018696  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327958;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9996;
+# Time: 2025-06-07T20:25:58.242157Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044741  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327958;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:58.260088Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015287  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327958;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9995;
+# Time: 2025-06-07T20:25:58.304530Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043908  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327958;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:58.324328Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017169  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327958;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9994;
+# Time: 2025-06-07T20:25:58.382725Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.057882  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327958;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:58.402986Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017335  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327958;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9993;
+# Time: 2025-06-07T20:25:58.447333Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043821  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327958;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:58.464548Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015162  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327958;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9992;
+# Time: 2025-06-07T20:25:58.508962Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044061  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327958;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:58.526562Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015618  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327958;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9991;
+# Time: 2025-06-07T20:25:58.570039Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043079  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327958;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:58.587963Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015243  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327958;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9990;
+# Time: 2025-06-07T20:25:58.633895Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.045406  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327958;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:58.650998Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015033  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327958;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9989;
+# Time: 2025-06-07T20:25:58.694647Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043292  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327958;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:58.712161Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015498  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327958;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9988;
+# Time: 2025-06-07T20:25:58.755735Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043148  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327958;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:58.772755Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015071  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327958;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9987;
+# Time: 2025-06-07T20:25:58.815996Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.042855  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327958;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:58.833084Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015159  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327958;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9986;
+# Time: 2025-06-07T20:25:58.877358Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043857  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327958;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:58.894888Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015469  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327958;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9985;
+# Time: 2025-06-07T20:25:58.938811Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043540  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327958;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:58.956166Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015396  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327958;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9984;
+# Time: 2025-06-07T20:25:59.000892Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044278  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327958;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:59.018604Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015163  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327959;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9983;
+# Time: 2025-06-07T20:25:59.061816Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.042902  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327959;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:59.079348Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015469  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327959;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9982;
+# Time: 2025-06-07T20:25:59.124367Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044675  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327959;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:59.142134Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015211  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327959;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9981;
+# Time: 2025-06-07T20:25:59.186198Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043641  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327959;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:59.203419Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.014965  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327959;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9980;
+# Time: 2025-06-07T20:25:59.247211Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043375  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327959;
+SELECT * FROM `comments` WHERE `post_id` = 9980 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:59.551268Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.014757  Lock_time: 0.000001 Rows_sent: 10001  Rows_examined: 20002
+SET timestamp=1749327959;
+SELECT `id`, `user_id`, `body`, `created_at`, `mime` FROM `posts` ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:25:59.595542Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016312  Lock_time: 0.000003 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327959;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10023;
+# Time: 2025-06-07T20:25:59.641788Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.045857  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1749327959;
+SELECT * FROM `comments` WHERE `post_id` = 10023 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:59.659970Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017289  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327959;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10000;
+# Time: 2025-06-07T20:25:59.709410Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.048895  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327959;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:59.728273Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016833  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327959;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9999;
+# Time: 2025-06-07T20:25:59.773718Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044981  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327959;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:59.790976Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.014993  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327959;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9998;
+# Time: 2025-06-07T20:25:59.834355Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043016  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327959;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:59.851729Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015085  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327959;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9997;
+# Time: 2025-06-07T20:25:59.897535Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.045443  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327959;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:59.915051Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015201  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327959;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9996;
+# Time: 2025-06-07T20:25:59.958410Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.042979  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327959;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:25:59.975714Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015038  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327959;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9995;
+# Time: 2025-06-07T20:26:00.021972Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.045837  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327959;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:00.039613Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015240  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327960;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9994;
+# Time: 2025-06-07T20:26:00.083762Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043732  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327960;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:00.101566Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015496  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327960;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9993;
+# Time: 2025-06-07T20:26:00.146294Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044312  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327960;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:00.163778Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015127  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327960;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9992;
+# Time: 2025-06-07T20:26:00.207497Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043337  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327960;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:00.225142Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015301  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327960;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9991;
+# Time: 2025-06-07T20:26:00.270981Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.045440  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327960;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:00.289224Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015167  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327960;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9990;
+# Time: 2025-06-07T20:26:00.333422Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043633  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327960;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:00.351106Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015384  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327960;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9989;
+# Time: 2025-06-07T20:26:00.395515Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044013  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327960;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:00.414885Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016995  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327960;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9988;
+# Time: 2025-06-07T20:26:00.464819Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049408  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327960;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:00.483768Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016271  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327960;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9987;
+# Time: 2025-06-07T20:26:00.526895Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.042633  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327960;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:00.544349Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015200  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327960;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9986;
+# Time: 2025-06-07T20:26:00.588571Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043746  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327960;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:00.606609Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015602  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327960;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9985;
+# Time: 2025-06-07T20:26:00.650571Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043482  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327960;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:00.668032Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015108  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327960;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9984;
+# Time: 2025-06-07T20:26:00.711937Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043522  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327960;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:00.729436Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015111  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327960;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9983;
+# Time: 2025-06-07T20:26:00.772673Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.042851  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327960;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:00.790814Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015769  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327960;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9982;
+# Time: 2025-06-07T20:26:00.835638Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044393  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327960;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:00.853221Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015318  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327960;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9981;
+# Time: 2025-06-07T20:26:00.898247Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044655  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327960;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:00.916431Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015822  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327960;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9980;
+# Time: 2025-06-07T20:26:00.964862Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.047975  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327960;
+SELECT * FROM `comments` WHERE `post_id` = 9980 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:00.989121Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.007922  Lock_time: 0.000003 Rows_sent: 9  Rows_examined: 10010
+SET timestamp=1749327960;
+SELECT `id`, `user_id`, `body`, `mime`, `created_at` FROM `posts` WHERE `user_id` = 851 ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:01.007323Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017617  Lock_time: 0.000003 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327960;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 8057;
+# Time: 2025-06-07T20:26:01.052285Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044468  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327961;
+SELECT * FROM `comments` WHERE `post_id` = 8057 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:01.070610Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015957  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327961;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 6005;
+# Time: 2025-06-07T20:26:01.115992Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044923  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327961;
+SELECT * FROM `comments` WHERE `post_id` = 6005 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:01.134120Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015790  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327961;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 4611;
+# Time: 2025-06-07T20:26:01.179029Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044529  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327961;
+SELECT * FROM `comments` WHERE `post_id` = 4611 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:01.196922Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015885  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327961;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 4130;
+# Time: 2025-06-07T20:26:01.241310Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044049  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327961;
+SELECT * FROM `comments` WHERE `post_id` = 4130 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:01.258694Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015435  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327961;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 3490;
+# Time: 2025-06-07T20:26:01.302775Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043784  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327961;
+SELECT * FROM `comments` WHERE `post_id` = 3490 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:01.320302Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015510  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327961;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 3465;
+# Time: 2025-06-07T20:26:01.365876Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.045188  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327961;
+SELECT * FROM `comments` WHERE `post_id` = 3465 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:01.383226Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015336  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327961;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 2807;
+# Time: 2025-06-07T20:26:01.428219Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044637  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327961;
+SELECT * FROM `comments` WHERE `post_id` = 2807 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:01.445698Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015408  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327961;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 2420;
+# Time: 2025-06-07T20:26:01.489844Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043792  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327961;
+SELECT * FROM `comments` WHERE `post_id` = 2420 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:01.507087Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015232  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327961;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 234;
+# Time: 2025-06-07T20:26:01.550271Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.042844  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327961;
+SELECT * FROM `comments` WHERE `post_id` = 234 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:01.568556Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016227  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327961;
+SELECT COUNT(*) AS count FROM `comments` WHERE `user_id` = 851;
+# Time: 2025-06-07T20:26:01.570799Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.001844  Lock_time: 0.000002 Rows_sent: 9  Rows_examined: 10001
+SET timestamp=1749327961;
+SELECT `id` FROM `posts` WHERE `user_id` = 851;
+# Time: 2025-06-07T20:26:01.587404Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016269  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327961;
+SELECT COUNT(*) AS count FROM `comments` WHERE `post_id` IN (234,2420,2807,3465,3490,4130,4611,6005,8057);
+# Time: 2025-06-07T20:26:01.641270Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016497  Lock_time: 0.000003 Rows_sent: 10001  Rows_examined: 20002
+SET timestamp=1749327961;
+SELECT `id`, `user_id`, `body`, `created_at`, `mime` FROM `posts` ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:01.683594Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015435  Lock_time: 0.000003 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327961;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10023;
+# Time: 2025-06-07T20:26:01.728162Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044207  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1749327961;
+SELECT * FROM `comments` WHERE `post_id` = 10023 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:01.744615Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015605  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327961;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10000;
+# Time: 2025-06-07T20:26:01.788643Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043614  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327961;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:01.805867Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015197  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327961;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9999;
+# Time: 2025-06-07T20:26:01.850016Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043759  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327961;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:01.867058Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015141  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327961;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9998;
+# Time: 2025-06-07T20:26:01.911968Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044605  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327961;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:01.929183Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015249  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327961;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9997;
+# Time: 2025-06-07T20:26:01.974458Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044911  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327961;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:01.991571Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015165  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327961;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9996;
+# Time: 2025-06-07T20:26:02.035799Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043861  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327961;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:02.053121Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015333  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327962;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9995;
+# Time: 2025-06-07T20:26:02.096868Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043387  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327962;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:02.114018Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015182  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327962;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9994;
+# Time: 2025-06-07T20:26:02.157335Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.042971  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327962;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:02.175103Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015266  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327962;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9993;
+# Time: 2025-06-07T20:26:02.218917Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043425  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327962;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:02.236769Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015692  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327962;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9992;
+# Time: 2025-06-07T20:26:02.280800Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043617  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327962;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:02.297813Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015013  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327962;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9991;
+# Time: 2025-06-07T20:26:02.341897Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043696  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327962;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:02.359245Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015081  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327962;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9990;
+# Time: 2025-06-07T20:26:02.402745Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043102  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327962;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:02.420585Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015562  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327962;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9989;
+# Time: 2025-06-07T20:26:02.464888Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043815  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327962;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:02.484406Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017157  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327962;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9988;
+# Time: 2025-06-07T20:26:02.533665Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.048822  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327962;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:02.552089Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016544  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327962;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9987;
+# Time: 2025-06-07T20:26:02.596162Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043629  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327962;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:02.614157Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015640  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327962;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9986;
+# Time: 2025-06-07T20:26:02.657778Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043290  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327962;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:02.675965Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015987  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327962;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9985;
+# Time: 2025-06-07T20:26:02.720139Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043695  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327962;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:02.737749Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015136  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327962;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9984;
+# Time: 2025-06-07T20:26:02.781965Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043809  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327962;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:02.799438Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015252  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327962;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9983;
+# Time: 2025-06-07T20:26:02.843205Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043376  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327962;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:02.860864Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015397  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327962;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9982;
+# Time: 2025-06-07T20:26:02.906274Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044986  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327962;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:02.924775Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015499  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327962;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9981;
+# Time: 2025-06-07T20:26:02.969141Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043743  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327962;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:02.987106Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015581  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327962;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9980;
+# Time: 2025-06-07T20:26:03.032161Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044592  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327962;
+SELECT * FROM `comments` WHERE `post_id` = 9980 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:03.071599Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.014488  Lock_time: 0.000003 Rows_sent: 10001  Rows_examined: 20002
+SET timestamp=1749327963;
+SELECT `id`, `user_id`, `body`, `created_at`, `mime` FROM `posts` ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:03.111182Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015131  Lock_time: 0.000003 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327963;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10023;
+# Time: 2025-06-07T20:26:03.155018Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043273  Lock_time: 0.000001 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1749327963;
+SELECT * FROM `comments` WHERE `post_id` = 10023 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:03.171235Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015280  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327963;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10000;
+# Time: 2025-06-07T20:26:03.215661Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043986  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327963;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:03.233683Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015652  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327963;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9999;
+# Time: 2025-06-07T20:26:03.279388Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.045279  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327963;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:03.296741Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015006  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327963;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9998;
+# Time: 2025-06-07T20:26:03.340064Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.042886  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327963;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:03.357553Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015151  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327963;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9997;
+# Time: 2025-06-07T20:26:03.401179Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043235  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327963;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:03.418845Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015344  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327963;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9996;
+# Time: 2025-06-07T20:26:03.462774Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043507  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327963;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:03.480331Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015156  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327963;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9995;
+# Time: 2025-06-07T20:26:03.524158Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043355  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327963;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:03.541827Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015381  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327963;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9994;
+# Time: 2025-06-07T20:26:03.586368Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044069  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327963;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:03.603993Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015188  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327963;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9993;
+# Time: 2025-06-07T20:26:03.647977Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043594  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327963;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:03.665650Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015308  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327963;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9992;
+# Time: 2025-06-07T20:26:03.709807Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043776  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327963;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:03.730860Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018563  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327963;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9991;
+# Time: 2025-06-07T20:26:03.780143Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.048768  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327963;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:03.799424Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016700  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327963;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9990;
+# Time: 2025-06-07T20:26:03.843388Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043516  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327963;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:03.861500Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015552  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327963;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9989;
+# Time: 2025-06-07T20:26:03.905120Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043252  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327963;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:03.923355Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016343  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327963;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9988;
+# Time: 2025-06-07T20:26:03.967763Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043953  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327963;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:03.985724Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015932  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327963;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9987;
+# Time: 2025-06-07T20:26:04.030138Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044025  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327963;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:04.047458Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015129  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327964;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9986;
+# Time: 2025-06-07T20:26:04.090942Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043093  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327964;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:04.108939Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015625  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327964;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9985;
+# Time: 2025-06-07T20:26:04.152698Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043326  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327964;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:04.169760Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015026  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327964;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9984;
+# Time: 2025-06-07T20:26:04.213795Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043683  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327964;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:04.231284Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015428  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327964;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9983;
+# Time: 2025-06-07T20:26:04.274659Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043024  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327964;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:04.291828Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015202  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327964;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9982;
+# Time: 2025-06-07T20:26:04.335873Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043620  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327964;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:04.352971Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015104  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327964;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9981;
+# Time: 2025-06-07T20:26:04.396518Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043191  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327964;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:04.413609Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015114  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327964;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9980;
+# Time: 2025-06-07T20:26:04.457911Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043945  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327964;
+SELECT * FROM `comments` WHERE `post_id` = 9980 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:04.501000Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.005292  Lock_time: 0.000002 Rows_sent: 10  Rows_examined: 10011
+SET timestamp=1749327964;
+SELECT `id`, `user_id`, `body`, `mime`, `created_at` FROM `posts` WHERE `user_id` = 517 ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:04.517541Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016081  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327964;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9995;
+# Time: 2025-06-07T20:26:04.563836Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.045845  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327964;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:04.584258Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017755  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327964;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9075;
+# Time: 2025-06-07T20:26:04.632733Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.048013  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327964;
+SELECT * FROM `comments` WHERE `post_id` = 9075 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:04.650760Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015585  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327964;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 8933;
+# Time: 2025-06-07T20:26:04.695038Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043783  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327964;
+SELECT * FROM `comments` WHERE `post_id` = 8933 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:04.713339Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015847  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327964;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 8741;
+# Time: 2025-06-07T20:26:04.757385Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043496  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327964;
+SELECT * FROM `comments` WHERE `post_id` = 8741 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:04.775755Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015945  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327964;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 6973;
+# Time: 2025-06-07T20:26:04.820023Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043861  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327964;
+SELECT * FROM `comments` WHERE `post_id` = 6973 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:04.837846Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015494  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327964;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 5639;
+# Time: 2025-06-07T20:26:04.882188Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043884  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327964;
+SELECT * FROM `comments` WHERE `post_id` = 5639 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:04.901115Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016549  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327964;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 4336;
+# Time: 2025-06-07T20:26:04.945143Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043541  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327964;
+SELECT * FROM `comments` WHERE `post_id` = 4336 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:04.963358Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015867  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327964;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 3125;
+# Time: 2025-06-07T20:26:05.008450Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044630  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327964;
+SELECT * FROM `comments` WHERE `post_id` = 3125 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:05.026296Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015434  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327965;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 2935;
+# Time: 2025-06-07T20:26:05.070684Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043989  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327965;
+SELECT * FROM `comments` WHERE `post_id` = 2935 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:05.088155Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015154  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327965;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 1390;
+# Time: 2025-06-07T20:26:05.132366Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043749  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327965;
+SELECT * FROM `comments` WHERE `post_id` = 1390 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:05.150385Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015619  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327965;
+SELECT COUNT(*) AS count FROM `comments` WHERE `user_id` = 517;
+# Time: 2025-06-07T20:26:05.152683Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.001863  Lock_time: 0.000001 Rows_sent: 10  Rows_examined: 10001
+SET timestamp=1749327965;
+SELECT `id` FROM `posts` WHERE `user_id` = 517;
+# Time: 2025-06-07T20:26:05.169391Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016309  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327965;
+SELECT COUNT(*) AS count FROM `comments` WHERE `post_id` IN (1390,2935,3125,4336,5639,6973,8741,8933,9075,9995);
+# Time: 2025-06-07T20:26:05.189359Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015426  Lock_time: 0.000004 Rows_sent: 10001  Rows_examined: 20002
+SET timestamp=1749327965;
+SELECT `id`, `user_id`, `body`, `created_at`, `mime` FROM `posts` ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:05.230213Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015165  Lock_time: 0.000003 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327965;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10023;
+# Time: 2025-06-07T20:26:05.273882Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043286  Lock_time: 0.000001 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1749327965;
+SELECT * FROM `comments` WHERE `post_id` = 10023 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:05.290074Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015213  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327965;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10000;
+# Time: 2025-06-07T20:26:05.333256Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.042793  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327965;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:05.350641Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015081  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327965;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9999;
+# Time: 2025-06-07T20:26:05.394322Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043240  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327965;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:05.411675Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015056  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327965;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9998;
+# Time: 2025-06-07T20:26:05.455638Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043571  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327965;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:05.474379Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016416  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327965;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9997;
+# Time: 2025-06-07T20:26:05.518745Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043923  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327965;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:05.536222Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015034  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327965;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9996;
+# Time: 2025-06-07T20:26:05.579833Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043222  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327965;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:05.597154Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015082  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327965;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9995;
+# Time: 2025-06-07T20:26:05.641401Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043853  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327965;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:05.658960Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015200  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327965;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9994;
+# Time: 2025-06-07T20:26:05.702847Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043531  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327965;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:05.720329Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015226  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327965;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9993;
+# Time: 2025-06-07T20:26:05.765330Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044537  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327965;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:05.783439Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015736  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327965;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9992;
+# Time: 2025-06-07T20:26:05.828001Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044141  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327965;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:05.845414Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015065  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327965;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9991;
+# Time: 2025-06-07T20:26:05.889879Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044090  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327965;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:05.907375Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015181  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327965;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9990;
+# Time: 2025-06-07T20:26:05.950679Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.042919  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327965;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:05.968630Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015320  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327965;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9989;
+# Time: 2025-06-07T20:26:06.013065Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044005  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327965;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:06.030789Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015320  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327966;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9988;
+# Time: 2025-06-07T20:26:06.074365Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043193  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327966;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:06.091861Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015081  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327966;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9987;
+# Time: 2025-06-07T20:26:06.136743Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044507  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327966;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:06.154208Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015038  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327966;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9986;
+# Time: 2025-06-07T20:26:06.197365Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.042780  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327966;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:06.214677Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015079  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327966;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9985;
+# Time: 2025-06-07T20:26:06.258678Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043608  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327966;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:06.276124Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015139  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327966;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9984;
+# Time: 2025-06-07T20:26:06.321013Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044457  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327966;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:06.338880Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015503  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327966;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9983;
+# Time: 2025-06-07T20:26:06.382466Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043121  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327966;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:06.399901Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015155  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327966;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9982;
+# Time: 2025-06-07T20:26:06.444405Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044113  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327966;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:06.461774Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015039  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327966;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9981;
+# Time: 2025-06-07T20:26:06.507549Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.045403  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327966;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:06.528763Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018170  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327966;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9980;
+# Time: 2025-06-07T20:26:06.578983Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049702  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327966;
+SELECT * FROM `comments` WHERE `post_id` = 9980 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:06.604810Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016289  Lock_time: 0.000004 Rows_sent: 10001  Rows_examined: 20002
+SET timestamp=1749327966;
+SELECT `id`, `user_id`, `body`, `created_at`, `mime` FROM `posts` ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:06.647062Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019227  Lock_time: 0.000003 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327966;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10023;
+# Time: 2025-06-07T20:26:06.697272Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049647  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1749327966;
+SELECT * FROM `comments` WHERE `post_id` = 10023 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:06.714657Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016314  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327966;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10000;
+# Time: 2025-06-07T20:26:06.759806Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044612  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327966;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:06.777425Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015171  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327966;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9999;
+# Time: 2025-06-07T20:26:06.821111Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043286  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327966;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:06.839175Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015257  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327966;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9998;
+# Time: 2025-06-07T20:26:06.883030Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043276  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327966;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:06.900878Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015352  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327966;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9997;
+# Time: 2025-06-07T20:26:06.943889Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.042582  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327966;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:06.961979Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015810  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327966;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9996;
+# Time: 2025-06-07T20:26:07.006189Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043822  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327966;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:07.023735Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015232  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327967;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9995;
+# Time: 2025-06-07T20:26:07.068587Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044464  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327967;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:07.086211Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015318  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327967;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9994;
+# Time: 2025-06-07T20:26:07.131701Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.045092  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327967;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:07.149817Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.014979  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327967;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9993;
+# Time: 2025-06-07T20:26:07.193386Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043071  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327967;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:07.211023Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015296  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327967;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9992;
+# Time: 2025-06-07T20:26:07.254811Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043356  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327967;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:07.272439Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015295  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327967;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9991;
+# Time: 2025-06-07T20:26:07.315963Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043089  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327967;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:07.333344Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015073  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327967;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9990;
+# Time: 2025-06-07T20:26:07.376691Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.042952  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327967;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:07.394089Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015119  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327967;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9989;
+# Time: 2025-06-07T20:26:07.438593Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044079  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327967;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:07.456340Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015314  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327967;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9988;
+# Time: 2025-06-07T20:26:07.500216Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043498  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327967;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:07.518866Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015942  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327967;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9987;
+# Time: 2025-06-07T20:26:07.563475Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044139  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327967;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:07.580679Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015209  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327967;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9986;
+# Time: 2025-06-07T20:26:07.624385Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043340  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327967;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:07.641514Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015243  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327967;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9985;
+# Time: 2025-06-07T20:26:07.686416Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044561  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327967;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:07.703520Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015072  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327967;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9984;
+# Time: 2025-06-07T20:26:07.747047Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043113  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327967;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:07.764404Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015386  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327967;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9983;
+# Time: 2025-06-07T20:26:07.808401Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043559  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327967;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:07.825658Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015319  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327967;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9982;
+# Time: 2025-06-07T20:26:07.869091Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043068  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327967;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:07.886289Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015252  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327967;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9981;
+# Time: 2025-06-07T20:26:07.929966Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.043233  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327967;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:07.947226Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015251  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327967;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9980;
+# Time: 2025-06-07T20:26:07.992156Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.044459  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327967;
+SELECT * FROM `comments` WHERE `post_id` = 9980 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:08.034598Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.014018  Lock_time: 0.000001 Rows_sent: 10001  Rows_examined: 20002
+SET timestamp=1749327968;
+SELECT `id`, `user_id`, `body`, `created_at`, `mime` FROM `posts` ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:08.080009Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016439  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327968;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10023;
+# Time: 2025-06-07T20:26:08.128826Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.048294  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1749327968;
+SELECT * FROM `comments` WHERE `post_id` = 10023 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:08.146813Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016898  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327968;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10000;
+# Time: 2025-06-07T20:26:08.195125Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.047808  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327968;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:08.213689Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016556  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327968;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9999;
+# Time: 2025-06-07T20:26:08.261798Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.047728  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327968;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:08.280757Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016821  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327968;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9998;
+# Time: 2025-06-07T20:26:08.328635Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.047405  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327968;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:08.347850Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017103  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327968;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9997;
+# Time: 2025-06-07T20:26:08.397197Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.048945  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327968;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:08.416697Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017135  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327968;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9996;
+# Time: 2025-06-07T20:26:08.466522Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049433  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327968;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:08.486514Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017251  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327968;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9995;
+# Time: 2025-06-07T20:26:08.536852Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049856  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327968;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:08.557421Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017897  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327968;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9994;
+# Time: 2025-06-07T20:26:08.608443Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050574  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327968;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:08.628467Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017781  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327968;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9993;
+# Time: 2025-06-07T20:26:08.679272Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050399  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327968;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:08.699443Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017869  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327968;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9992;
+# Time: 2025-06-07T20:26:08.752769Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052913  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327968;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:08.774529Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019265  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327968;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9991;
+# Time: 2025-06-07T20:26:08.828079Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053042  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327968;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:08.848918Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018471  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327968;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9990;
+# Time: 2025-06-07T20:26:08.901144Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051725  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327968;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:08.922128Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018047  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327968;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9989;
+# Time: 2025-06-07T20:26:08.974437Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051904  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327968;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:08.995316Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018645  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327968;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9988;
+# Time: 2025-06-07T20:26:09.048324Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052454  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327968;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:09.069043Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018390  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327969;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9987;
+# Time: 2025-06-07T20:26:09.122255Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052719  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327969;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:09.142750Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018203  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327969;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9986;
+# Time: 2025-06-07T20:26:09.193607Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050447  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327969;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:09.213437Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017555  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327969;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9985;
+# Time: 2025-06-07T20:26:09.264082Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050248  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327969;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:09.283983Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017657  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327969;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9984;
+# Time: 2025-06-07T20:26:09.338150Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053629  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327969;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:09.359203Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018662  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327969;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9983;
+# Time: 2025-06-07T20:26:09.414733Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.055039  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327969;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:09.436894Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019062  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327969;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9982;
+# Time: 2025-06-07T20:26:09.491207Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053776  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327969;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:09.513129Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019124  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327969;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9981;
+# Time: 2025-06-07T20:26:09.567932Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054332  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327969;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:09.589448Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018529  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327969;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9980;
+# Time: 2025-06-07T20:26:09.642841Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052676  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327969;
+SELECT * FROM `comments` WHERE `post_id` = 9980 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:09.668325Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016529  Lock_time: 0.000002 Rows_sent: 10001  Rows_examined: 20002
+SET timestamp=1749327969;
+SELECT `id`, `user_id`, `body`, `created_at`, `mime` FROM `posts` ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:09.711308Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018480  Lock_time: 0.000003 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327969;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10023;
+# Time: 2025-06-07T20:26:09.764496Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052652  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1749327969;
+SELECT * FROM `comments` WHERE `post_id` = 10023 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:09.784179Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018434  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327969;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10000;
+# Time: 2025-06-07T20:26:09.837104Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052417  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327969;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:09.857721Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018192  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327969;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9999;
+# Time: 2025-06-07T20:26:09.909518Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051394  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327969;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:09.929349Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017683  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327969;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9998;
+# Time: 2025-06-07T20:26:09.980267Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050497  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327969;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:09.999997Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017561  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327969;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9997;
+# Time: 2025-06-07T20:26:10.051243Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050829  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327970;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:10.071262Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017692  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327970;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9996;
+# Time: 2025-06-07T20:26:10.122012Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050339  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327970;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:10.142013Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017667  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327970;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9995;
+# Time: 2025-06-07T20:26:10.192971Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050561  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327970;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:10.212935Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017574  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327970;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9994;
+# Time: 2025-06-07T20:26:10.263757Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050433  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327970;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:10.283846Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017926  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327970;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9993;
+# Time: 2025-06-07T20:26:10.335501Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051223  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327970;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:10.355401Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017671  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327970;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9992;
+# Time: 2025-06-07T20:26:10.405981Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050178  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327970;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:10.425699Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017496  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327970;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9991;
+# Time: 2025-06-07T20:26:10.476426Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050300  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327970;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:10.497225Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017529  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327970;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9990;
+# Time: 2025-06-07T20:26:10.547534Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049924  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327970;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:10.567292Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017620  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327970;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9989;
+# Time: 2025-06-07T20:26:10.618134Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050331  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327970;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:10.638536Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018135  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327970;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9988;
+# Time: 2025-06-07T20:26:10.688210Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049237  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327970;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:10.708088Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017512  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327970;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9987;
+# Time: 2025-06-07T20:26:10.758002Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049453  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327970;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:10.777610Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017360  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327970;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9986;
+# Time: 2025-06-07T20:26:10.829487Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051504  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327970;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:10.851377Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019303  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327970;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9985;
+# Time: 2025-06-07T20:26:10.906659Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054783  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327970;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:10.928190Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019132  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327970;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9984;
+# Time: 2025-06-07T20:26:10.985627Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.056937  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327970;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:11.007038Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019003  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327970;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9983;
+# Time: 2025-06-07T20:26:11.060980Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053446  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327971;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:11.081549Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018227  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327971;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9982;
+# Time: 2025-06-07T20:26:11.134728Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052697  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327971;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:11.155286Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018237  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327971;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9981;
+# Time: 2025-06-07T20:26:11.207552Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051831  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327971;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:11.228016Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018105  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327971;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9980;
+# Time: 2025-06-07T20:26:11.280656Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052246  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327971;
+SELECT * FROM `comments` WHERE `post_id` = 9980 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:11.305990Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015428  Lock_time: 0.000002 Rows_sent: 10001  Rows_examined: 20002
+SET timestamp=1749327971;
+SELECT `id`, `user_id`, `body`, `created_at`, `mime` FROM `posts` ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:11.348016Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018534  Lock_time: 0.000003 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327971;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10023;
+# Time: 2025-06-07T20:26:11.400994Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052472  Lock_time: 0.000001 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1749327971;
+SELECT * FROM `comments` WHERE `post_id` = 10023 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:11.420185Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017971  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327971;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10000;
+# Time: 2025-06-07T20:26:11.471972Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051281  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327971;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:11.491892Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017672  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327971;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9999;
+# Time: 2025-06-07T20:26:11.543084Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050775  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327971;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:11.562741Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017565  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327971;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9998;
+# Time: 2025-06-07T20:26:11.614475Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051304  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327971;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:11.634451Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017542  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327971;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9997;
+# Time: 2025-06-07T20:26:11.685370Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050496  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327971;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:11.705377Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017800  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327971;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9996;
+# Time: 2025-06-07T20:26:11.756165Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050365  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327971;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:11.775905Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017515  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327971;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9995;
+# Time: 2025-06-07T20:26:11.827326Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051037  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327971;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:11.847323Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017693  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327971;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9994;
+# Time: 2025-06-07T20:26:11.897848Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050045  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327971;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:11.917704Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017611  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327971;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9993;
+# Time: 2025-06-07T20:26:11.968353Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050254  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327971;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:11.988117Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017549  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327971;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9992;
+# Time: 2025-06-07T20:26:12.039513Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051024  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327971;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:12.059392Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017605  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327972;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9991;
+# Time: 2025-06-07T20:26:12.110092Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050313  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327972;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:12.130607Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017859  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327972;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9990;
+# Time: 2025-06-07T20:26:12.184943Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053896  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327972;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:12.206813Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019280  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327972;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9989;
+# Time: 2025-06-07T20:26:12.260800Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053398  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327972;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:12.281833Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018698  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327972;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9988;
+# Time: 2025-06-07T20:26:12.335753Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053554  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327972;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:12.356453Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018222  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327972;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9987;
+# Time: 2025-06-07T20:26:12.408529Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051561  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327972;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:12.429030Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018173  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327972;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9986;
+# Time: 2025-06-07T20:26:12.481943Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052484  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327972;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:12.502515Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018228  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327972;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9985;
+# Time: 2025-06-07T20:26:12.553993Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051044  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327972;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:12.573791Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017559  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327972;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9984;
+# Time: 2025-06-07T20:26:12.624937Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050745  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327972;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:12.644720Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017517  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327972;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9983;
+# Time: 2025-06-07T20:26:12.695344Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050196  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327972;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:12.715181Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017628  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327972;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9982;
+# Time: 2025-06-07T20:26:12.765941Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050335  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327972;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:12.786064Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017917  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327972;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9981;
+# Time: 2025-06-07T20:26:12.836577Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050102  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327972;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:12.856235Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017510  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327972;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9980;
+# Time: 2025-06-07T20:26:12.909187Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052455  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327972;
+SELECT * FROM `comments` WHERE `post_id` = 9980 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:12.936754Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017132  Lock_time: 0.000001 Rows_sent: 10001  Rows_examined: 20002
+SET timestamp=1749327972;
+SELECT `id`, `user_id`, `body`, `created_at`, `mime` FROM `posts` ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:12.982276Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018815  Lock_time: 0.000003 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327972;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10023;
+# Time: 2025-06-07T20:26:13.037341Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054557  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1749327972;
+SELECT * FROM `comments` WHERE `post_id` = 10023 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:13.057238Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018638  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327973;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10000;
+# Time: 2025-06-07T20:26:13.112006Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054248  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327973;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:13.133157Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018665  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327973;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9999;
+# Time: 2025-06-07T20:26:13.187852Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054272  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327973;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:13.209429Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018466  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327973;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9998;
+# Time: 2025-06-07T20:26:13.261627Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051693  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327973;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:13.281962Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018052  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327973;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9997;
+# Time: 2025-06-07T20:26:13.333993Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051635  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327973;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:13.354260Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017945  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327973;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9996;
+# Time: 2025-06-07T20:26:13.405107Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050430  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327973;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:13.425220Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017864  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327973;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9995;
+# Time: 2025-06-07T20:26:13.476936Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051345  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327973;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:13.497256Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017927  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327973;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9994;
+# Time: 2025-06-07T20:26:13.548323Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050653  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327973;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:13.568796Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017553  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327973;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9993;
+# Time: 2025-06-07T20:26:13.619518Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050224  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327973;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:13.639309Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017529  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327973;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9992;
+# Time: 2025-06-07T20:26:13.690505Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050790  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327973;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:13.710351Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017574  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327973;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9991;
+# Time: 2025-06-07T20:26:13.761625Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050851  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327973;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:13.781655Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017803  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327973;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9990;
+# Time: 2025-06-07T20:26:13.831984Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049935  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327973;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:13.851760Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017617  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327973;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9989;
+# Time: 2025-06-07T20:26:13.902727Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050542  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327973;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:13.923472Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017844  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327973;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9988;
+# Time: 2025-06-07T20:26:13.974946Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050976  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327973;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:13.995110Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017918  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327973;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9987;
+# Time: 2025-06-07T20:26:14.046946Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051374  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327973;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:14.066800Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017642  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327974;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9986;
+# Time: 2025-06-07T20:26:14.117523Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050298  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327974;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:14.137916Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018202  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327974;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9985;
+# Time: 2025-06-07T20:26:14.188676Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050288  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327974;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:14.208376Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017565  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327974;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9984;
+# Time: 2025-06-07T20:26:14.259593Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050831  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327974;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:14.280669Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017550  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327974;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9983;
+# Time: 2025-06-07T20:26:14.331217Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050141  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327974;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:14.351140Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017567  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327974;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9982;
+# Time: 2025-06-07T20:26:14.400370Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.048832  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327974;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:14.419783Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017111  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327974;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9981;
+# Time: 2025-06-07T20:26:14.468900Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.048726  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327974;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:14.488748Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017586  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327974;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9980;
+# Time: 2025-06-07T20:26:14.541151Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051946  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327974;
+SELECT * FROM `comments` WHERE `post_id` = 9980 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:14.567602Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.015422  Lock_time: 0.000002 Rows_sent: 10001  Rows_examined: 20002
+SET timestamp=1749327974;
+SELECT `id`, `user_id`, `body`, `created_at`, `mime` FROM `posts` ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:14.608502Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017823  Lock_time: 0.000003 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327974;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10023;
+# Time: 2025-06-07T20:26:14.659831Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050815  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1749327974;
+SELECT * FROM `comments` WHERE `post_id` = 10023 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:14.678793Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017758  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327974;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10000;
+# Time: 2025-06-07T20:26:14.729609Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050333  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327974;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:14.749328Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017521  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327974;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9999;
+# Time: 2025-06-07T20:26:14.799987Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050258  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327974;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:14.820148Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017967  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327974;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9998;
+# Time: 2025-06-07T20:26:14.870981Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050416  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327974;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:14.890754Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017584  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327974;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9997;
+# Time: 2025-06-07T20:26:14.943980Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052696  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327974;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:14.965279Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018985  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327974;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9996;
+# Time: 2025-06-07T20:26:15.023690Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.057802  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327974;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:15.047978Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.021124  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327975;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9995;
+# Time: 2025-06-07T20:26:15.108417Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.059817  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327975;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:15.131185Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019660  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327975;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9994;
+# Time: 2025-06-07T20:26:15.186934Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.055198  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327975;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:15.208446Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018999  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327975;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9993;
+# Time: 2025-06-07T20:26:15.262477Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053510  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327975;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:15.284176Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019370  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327975;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9992;
+# Time: 2025-06-07T20:26:15.337559Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052922  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327975;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:15.357999Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018131  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327975;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9991;
+# Time: 2025-06-07T20:26:15.410215Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051776  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327975;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:15.430803Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018192  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327975;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9990;
+# Time: 2025-06-07T20:26:15.482624Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051407  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327975;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:15.502464Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017650  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327975;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9989;
+# Time: 2025-06-07T20:26:15.554143Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051207  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327975;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:15.573913Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017517  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327975;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9988;
+# Time: 2025-06-07T20:26:15.624620Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050319  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327975;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:15.644507Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017620  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327975;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9987;
+# Time: 2025-06-07T20:26:15.695439Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050451  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327975;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:15.715198Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017555  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327975;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9986;
+# Time: 2025-06-07T20:26:15.765818Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050225  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327975;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:15.785653Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017635  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327975;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9985;
+# Time: 2025-06-07T20:26:15.836064Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050077  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327975;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:15.855780Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017530  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327975;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9984;
+# Time: 2025-06-07T20:26:15.906521Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050321  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327975;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:15.927255Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018019  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327975;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9983;
+# Time: 2025-06-07T20:26:15.978892Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051230  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327975;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:15.999280Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017625  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327975;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9982;
+# Time: 2025-06-07T20:26:16.050218Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050521  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327975;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:16.070087Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017568  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327976;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9981;
+# Time: 2025-06-07T20:26:16.121005Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050521  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327976;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:16.140839Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017556  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327976;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9980;
+# Time: 2025-06-07T20:26:16.192797Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051534  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327976;
+SELECT * FROM `comments` WHERE `post_id` = 9980 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:16.284015Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016850  Lock_time: 0.000002 Rows_sent: 10001  Rows_examined: 20002
+SET timestamp=1749327976;
+SELECT `id`, `user_id`, `body`, `created_at`, `mime` FROM `posts` ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:16.332732Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018545  Lock_time: 0.000003 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327976;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10023;
+# Time: 2025-06-07T20:26:16.387877Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054623  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1749327976;
+SELECT * FROM `comments` WHERE `post_id` = 10023 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:16.407554Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018516  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327976;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10000;
+# Time: 2025-06-07T20:26:16.460884Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052787  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327976;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:16.481251Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018086  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327976;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9999;
+# Time: 2025-06-07T20:26:16.532239Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050538  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327976;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:16.551964Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017514  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327976;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9998;
+# Time: 2025-06-07T20:26:16.602781Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050428  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327976;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:16.623071Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018116  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327976;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9997;
+# Time: 2025-06-07T20:26:16.674148Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050574  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327976;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:16.694487Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017925  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327976;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9996;
+# Time: 2025-06-07T20:26:16.745678Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050771  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327976;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:16.765937Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017657  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327976;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9995;
+# Time: 2025-06-07T20:26:16.816374Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049950  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327976;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:16.836114Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017553  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327976;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9994;
+# Time: 2025-06-07T20:26:16.886568Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050039  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327976;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:16.906549Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017556  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327976;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9993;
+# Time: 2025-06-07T20:26:16.957449Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050505  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327976;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:16.977826Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018171  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327976;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9992;
+# Time: 2025-06-07T20:26:17.028449Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050181  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327976;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:17.048381Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017644  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327977;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9991;
+# Time: 2025-06-07T20:26:17.100312Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051540  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327977;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:17.121649Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019059  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327977;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9990;
+# Time: 2025-06-07T20:26:17.178999Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.056769  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327977;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:17.200271Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018765  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327977;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9989;
+# Time: 2025-06-07T20:26:17.254680Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053836  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327977;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:17.275380Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018371  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327977;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9988;
+# Time: 2025-06-07T20:26:17.327871Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052086  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327977;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:17.348299Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018088  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327977;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9987;
+# Time: 2025-06-07T20:26:17.400620Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051957  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327977;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:17.421002Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018100  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327977;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9986;
+# Time: 2025-06-07T20:26:17.473642Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052231  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327977;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:17.493444Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017545  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327977;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9985;
+# Time: 2025-06-07T20:26:17.544210Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050318  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327977;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:17.564632Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017500  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327977;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9984;
+# Time: 2025-06-07T20:26:17.616100Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050978  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327977;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:17.635862Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017538  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327977;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9983;
+# Time: 2025-06-07T20:26:17.686350Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050052  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327977;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:17.707555Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018266  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327977;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9982;
+# Time: 2025-06-07T20:26:17.762023Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053951  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327977;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:17.784133Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019040  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327977;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9981;
+# Time: 2025-06-07T20:26:17.838649Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053955  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327977;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:17.860811Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019170  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327977;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9980;
+# Time: 2025-06-07T20:26:17.915601Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054218  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327977;
+SELECT * FROM `comments` WHERE `post_id` = 9980 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:17.964596Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.033690  Lock_time: 0.000002 Rows_sent: 10001  Rows_examined: 20002
+SET timestamp=1749327977;
+SELECT `id`, `user_id`, `body`, `created_at`, `mime` FROM `posts` ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:18.011239Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.020039  Lock_time: 0.000003 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327977;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10023;
+# Time: 2025-06-07T20:26:18.066439Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054692  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1749327978;
+SELECT * FROM `comments` WHERE `post_id` = 10023 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:18.086608Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018958  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327978;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10000;
+# Time: 2025-06-07T20:26:18.141421Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054239  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327978;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:18.162028Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018218  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327978;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9999;
+# Time: 2025-06-07T20:26:18.214296Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051865  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327978;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:18.235880Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018092  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327978;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9998;
+# Time: 2025-06-07T20:26:18.287772Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051490  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327978;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:18.308322Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018133  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327978;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9997;
+# Time: 2025-06-07T20:26:18.359016Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050273  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327978;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:18.378756Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017490  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327978;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9996;
+# Time: 2025-06-07T20:26:18.429117Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049975  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327978;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:18.448972Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017548  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327978;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9995;
+# Time: 2025-06-07T20:26:18.500100Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050703  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327978;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:18.520174Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017853  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327978;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9994;
+# Time: 2025-06-07T20:26:18.571230Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050648  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327978;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:18.591503Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018054  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327978;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9993;
+# Time: 2025-06-07T20:26:18.642682Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050674  Lock_time: 0.000005 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327978;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:18.663368Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017794  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327978;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9992;
+# Time: 2025-06-07T20:26:18.714504Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050657  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327978;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:18.735059Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017998  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327978;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9991;
+# Time: 2025-06-07T20:26:18.786005Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050446  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327978;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:18.805823Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017590  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327978;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9990;
+# Time: 2025-06-07T20:26:18.856193Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049951  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327978;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:18.875970Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017583  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327978;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9989;
+# Time: 2025-06-07T20:26:18.926282Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049962  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327978;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:18.946063Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017647  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327978;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9988;
+# Time: 2025-06-07T20:26:18.998862Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052392  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327978;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:19.018807Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017656  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327979;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9987;
+# Time: 2025-06-07T20:26:19.069466Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050176  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327979;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:19.089719Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017802  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327979;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9986;
+# Time: 2025-06-07T20:26:19.140348Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050233  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327979;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:19.160306Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017739  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327979;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9985;
+# Time: 2025-06-07T20:26:19.222196Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.061360  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327979;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:19.244754Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019964  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327979;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9984;
+# Time: 2025-06-07T20:26:19.298651Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053363  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327979;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:19.319755Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018751  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327979;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9983;
+# Time: 2025-06-07T20:26:19.371928Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051795  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327979;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:19.392290Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018083  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327979;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9982;
+# Time: 2025-06-07T20:26:19.444246Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051546  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327979;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:19.464603Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018049  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327979;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9981;
+# Time: 2025-06-07T20:26:19.517003Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052062  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327979;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:19.537287Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017992  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327979;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9980;
+# Time: 2025-06-07T20:26:19.588455Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050616  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327979;
+SELECT * FROM `comments` WHERE `post_id` = 9980 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:19.615579Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017587  Lock_time: 0.000004 Rows_sent: 10001  Rows_examined: 20002
+SET timestamp=1749327979;
+SELECT `id`, `user_id`, `body`, `created_at`, `mime` FROM `posts` ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:19.656838Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018189  Lock_time: 0.000003 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327979;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10023;
+# Time: 2025-06-07T20:26:19.709347Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051999  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100001
+SET timestamp=1749327979;
+SELECT * FROM `comments` WHERE `post_id` = 10023 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:19.727997Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017478  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327979;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10000;
+# Time: 2025-06-07T20:26:19.779004Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050500  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327979;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:19.798834Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017695  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327979;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9999;
+# Time: 2025-06-07T20:26:19.850466Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051200  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327979;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:19.870157Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017563  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327979;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9998;
+# Time: 2025-06-07T20:26:19.920928Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050376  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327979;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:19.940641Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017561  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327979;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9997;
+# Time: 2025-06-07T20:26:19.991453Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050409  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327979;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:20.012324Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018114  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327979;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9996;
+# Time: 2025-06-07T20:26:20.063760Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050939  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327980;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:20.086187Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017828  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327980;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9995;
+# Time: 2025-06-07T20:26:20.137459Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050749  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327980;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:20.157257Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017584  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327980;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9994;
+# Time: 2025-06-07T20:26:20.208037Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050390  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327980;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:20.227917Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017636  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327980;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9993;
+# Time: 2025-06-07T20:26:20.278452Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050138  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327980;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:20.298377Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017627  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327980;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9992;
+# Time: 2025-06-07T20:26:20.348865Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050098  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327980;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:20.368603Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017362  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327980;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9991;
+# Time: 2025-06-07T20:26:20.418707Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049708  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327980;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:20.437912Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017081  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327980;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9990;
+# Time: 2025-06-07T20:26:20.486796Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.048501  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327980;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:20.507077Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018102  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327980;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9989;
+# Time: 2025-06-07T20:26:20.561621Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054043  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327980;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:20.584287Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.020232  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327980;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9988;
+# Time: 2025-06-07T20:26:20.638918Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054002  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327980;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:20.660645Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018662  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327980;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9987;
+# Time: 2025-06-07T20:26:20.714394Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053235  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327980;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:20.736165Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018743  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327980;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9986;
+# Time: 2025-06-07T20:26:20.789135Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052463  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327980;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:20.809685Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018224  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327980;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9985;
+# Time: 2025-06-07T20:26:20.862226Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052109  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327980;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:20.882785Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018143  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327980;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9984;
+# Time: 2025-06-07T20:26:20.934384Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051179  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327980;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:20.954483Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017877  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327980;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9983;
+# Time: 2025-06-07T20:26:21.006894Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052005  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327980;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:21.026944Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017567  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327981;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9982;
+# Time: 2025-06-07T20:26:21.080213Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052767  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327981;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:21.100994Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018468  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327981;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9981;
+# Time: 2025-06-07T20:26:21.153393Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051975  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327981;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:21.173350Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017610  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327981;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9980;
+# Time: 2025-06-07T20:26:21.224254Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050239  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327981;
+SELECT * FROM `comments` WHERE `post_id` = 9980 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:21.286169Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.010960  Lock_time: 0.000002 Rows_sent: 10  Rows_examined: 10011
+SET timestamp=1749327981;
+SELECT `id`, `user_id`, `body`, `mime`, `created_at` FROM `posts` WHERE `user_id` = 245 ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:21.313693Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.026833  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327981;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 8501;
+# Time: 2025-06-07T20:26:21.373963Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.059622  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327981;
+SELECT * FROM `comments` WHERE `post_id` = 8501 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:21.397432Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.020151  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327981;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 7309;
+# Time: 2025-06-07T20:26:21.455161Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.057180  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327981;
+SELECT * FROM `comments` WHERE `post_id` = 7309 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:21.477747Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019457  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327981;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 6837;
+# Time: 2025-06-07T20:26:21.533959Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.055672  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327981;
+SELECT * FROM `comments` WHERE `post_id` = 6837 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:21.556361Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019316  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327981;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 6765;
+# Time: 2025-06-07T20:26:21.611060Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054166  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327981;
+SELECT * FROM `comments` WHERE `post_id` = 6765 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:21.632345Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018887  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327981;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 6416;
+# Time: 2025-06-07T20:26:21.685221Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052429  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327981;
+SELECT * FROM `comments` WHERE `post_id` = 6416 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:21.706320Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018725  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327981;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 5944;
+# Time: 2025-06-07T20:26:21.759539Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052738  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327981;
+SELECT * FROM `comments` WHERE `post_id` = 5944 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:21.780224Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018404  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327981;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 3798;
+# Time: 2025-06-07T20:26:21.832014Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051309  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327981;
+SELECT * FROM `comments` WHERE `post_id` = 3798 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:21.852543Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018150  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327981;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 2273;
+# Time: 2025-06-07T20:26:21.903664Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050700  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327981;
+SELECT * FROM `comments` WHERE `post_id` = 2273 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:21.923597Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017707  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327981;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 2097;
+# Time: 2025-06-07T20:26:21.974719Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050670  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327981;
+SELECT * FROM `comments` WHERE `post_id` = 2097 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:21.995774Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018822  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327981;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 1805;
+# Time: 2025-06-07T20:26:22.049089Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052811  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100004
+SET timestamp=1749327981;
+SELECT * FROM `comments` WHERE `post_id` = 1805 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:22.069548Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018082  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327982;
+SELECT COUNT(*) AS count FROM `comments` WHERE `user_id` = 245;
+# Time: 2025-06-07T20:26:22.072113Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.002168  Lock_time: 0.000002 Rows_sent: 10  Rows_examined: 10001
+SET timestamp=1749327982;
+SELECT `id` FROM `posts` WHERE `user_id` = 245;
+# Time: 2025-06-07T20:26:22.091794Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019277  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100001
+SET timestamp=1749327982;
+SELECT COUNT(*) AS count FROM `comments` WHERE `post_id` IN (1805,2097,2273,3798,5944,6416,6765,6837,7309,8501);
+# Time: 2025-06-07T20:26:22.198508Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016140  Lock_time: 0.000002 Rows_sent: 10001  Rows_examined: 20002
+SET timestamp=1749327982;
+SELECT `id`, `user_id`, `body`, `created_at`, `mime` FROM `posts` ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:22.249562Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018703  Lock_time: 0.000003 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327982;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10023;
+# Time: 2025-06-07T20:26:22.302422Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052315  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100002
+SET timestamp=1749327982;
+SELECT * FROM `comments` WHERE `post_id` = 10023 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:22.322038Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018366  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327982;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10000;
+# Time: 2025-06-07T20:26:22.375650Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053138  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327982;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:22.396409Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018438  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327982;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9999;
+# Time: 2025-06-07T20:26:22.447726Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050889  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327982;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:22.467686Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017614  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327982;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9998;
+# Time: 2025-06-07T20:26:22.519050Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050864  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327982;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:22.539648Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017703  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327982;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9997;
+# Time: 2025-06-07T20:26:22.592086Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051891  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327982;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:22.611936Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017610  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327982;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9996;
+# Time: 2025-06-07T20:26:22.662706Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050375  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327982;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:22.682590Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017711  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327982;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9995;
+# Time: 2025-06-07T20:26:22.733577Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050589  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327982;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:22.753740Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017896  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327982;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9994;
+# Time: 2025-06-07T20:26:22.804357Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050210  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327982;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:22.824658Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018077  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327982;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9993;
+# Time: 2025-06-07T20:26:22.876043Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050930  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327982;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:22.896393Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018088  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327982;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9992;
+# Time: 2025-06-07T20:26:22.947617Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050791  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327982;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:22.967998Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018097  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327982;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9991;
+# Time: 2025-06-07T20:26:23.019595Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051105  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327982;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:23.039526Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017661  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327983;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9990;
+# Time: 2025-06-07T20:26:23.091416Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051490  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327983;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:23.111730Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018052  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327983;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9989;
+# Time: 2025-06-07T20:26:23.162594Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050421  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327983;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:23.182504Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017672  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327983;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9988;
+# Time: 2025-06-07T20:26:23.231979Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049066  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327983;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:23.251146Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017040  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327983;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9987;
+# Time: 2025-06-07T20:26:23.302355Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050818  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327983;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:23.323351Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018383  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327983;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9986;
+# Time: 2025-06-07T20:26:23.388439Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.064648  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327983;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:23.412204Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.020972  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327983;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9985;
+# Time: 2025-06-07T20:26:23.473898Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.061204  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327983;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:23.496599Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019589  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327983;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9984;
+# Time: 2025-06-07T20:26:23.552306Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.055143  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327983;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:23.573532Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018922  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327983;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9983;
+# Time: 2025-06-07T20:26:23.627982Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053963  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327983;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:23.649509Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019152  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327983;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9982;
+# Time: 2025-06-07T20:26:23.702540Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052526  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327983;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:23.723064Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018270  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327983;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9981;
+# Time: 2025-06-07T20:26:23.775907Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052352  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327983;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:23.796534Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018348  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327983;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9980;
+# Time: 2025-06-07T20:26:23.848711Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051736  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327983;
+SELECT * FROM `comments` WHERE `post_id` = 9980 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:23.970410Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052630  Lock_time: 0.000003 Rows_sent: 10001  Rows_examined: 20002
+SET timestamp=1749327983;
+SELECT `id`, `user_id`, `body`, `created_at`, `mime` FROM `posts` ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:24.024410Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.021047  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327984;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10023;
+# Time: 2025-06-07T20:26:24.087306Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.062500  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100002
+SET timestamp=1749327984;
+SELECT * FROM `comments` WHERE `post_id` = 10023 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:24.108793Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.020312  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327984;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10000;
+# Time: 2025-06-07T20:26:24.166561Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.057235  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327984;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:24.189160Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019456  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327984;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9999;
+# Time: 2025-06-07T20:26:24.245544Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.055866  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327984;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:24.267417Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018830  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327984;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9998;
+# Time: 2025-06-07T20:26:24.321584Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053659  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327984;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:24.342873Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018260  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327984;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9997;
+# Time: 2025-06-07T20:26:24.396029Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052619  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327984;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:24.417292Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018390  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327984;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9996;
+# Time: 2025-06-07T20:26:24.470747Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052918  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327984;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:24.491857Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018437  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327984;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9995;
+# Time: 2025-06-07T20:26:24.542518Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050192  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327984;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:24.562513Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017784  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327984;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9994;
+# Time: 2025-06-07T20:26:24.613403Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050483  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327984;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:24.633701Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018122  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327984;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9993;
+# Time: 2025-06-07T20:26:24.684690Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050580  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327984;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:24.704492Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017674  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327984;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9992;
+# Time: 2025-06-07T20:26:24.755069Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050178  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327984;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:24.775047Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017731  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327984;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9991;
+# Time: 2025-06-07T20:26:24.825510Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050073  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327984;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:24.845450Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017769  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327984;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9990;
+# Time: 2025-06-07T20:26:24.896322Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050350  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327984;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:24.916140Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017494  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327984;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9989;
+# Time: 2025-06-07T20:26:24.967352Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050819  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327984;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:24.986746Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017229  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327984;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9988;
+# Time: 2025-06-07T20:26:25.037227Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050113  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327984;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:25.057082Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017612  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327985;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9987;
+# Time: 2025-06-07T20:26:25.108125Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050661  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327985;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:25.127927Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017537  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327985;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9986;
+# Time: 2025-06-07T20:26:25.178915Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050580  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327985;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:25.198799Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017635  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327985;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9985;
+# Time: 2025-06-07T20:26:25.249218Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049981  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327985;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:25.269169Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017745  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327985;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9984;
+# Time: 2025-06-07T20:26:25.318226Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.048669  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327985;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:25.337365Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017034  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327985;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9983;
+# Time: 2025-06-07T20:26:25.386860Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049111  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327985;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:25.406194Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017144  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327985;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9982;
+# Time: 2025-06-07T20:26:25.461026Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054439  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327985;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:25.485687Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.022244  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327985;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9981;
+# Time: 2025-06-07T20:26:25.539843Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053628  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327985;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:25.561592Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018673  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327985;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9980;
+# Time: 2025-06-07T20:26:25.615454Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053362  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327985;
+SELECT * FROM `comments` WHERE `post_id` = 9980 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:25.669504Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.036982  Lock_time: 0.000004 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327985;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 8501;
+# Time: 2025-06-07T20:26:25.727369Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.057369  Lock_time: 0.000002 Rows_sent: 8  Rows_examined: 100010
+SET timestamp=1749327985;
+SELECT * FROM `comments` WHERE `post_id` = 8501 ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:25.891820Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.077030  Lock_time: 0.000002 Rows_sent: 10001  Rows_examined: 20002
+SET timestamp=1749327985;
+SELECT `id`, `user_id`, `body`, `created_at`, `mime` FROM `posts` ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:26.008531Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.023957  Lock_time: 0.000004 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327985;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10023;
+# Time: 2025-06-07T20:26:26.073896Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.064871  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100002
+SET timestamp=1749327986;
+SELECT * FROM `comments` WHERE `post_id` = 10023 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:26.097199Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.022172  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327986;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10000;
+# Time: 2025-06-07T20:26:26.167655Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.069801  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327986;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:26.193591Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.022235  Lock_time: 0.000003 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327986;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9999;
+# Time: 2025-06-07T20:26:26.254626Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.060432  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327986;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:26.278605Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.020831  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327986;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9998;
+# Time: 2025-06-07T20:26:26.336869Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.057692  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327986;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:26.359218Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019868  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327986;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9997;
+# Time: 2025-06-07T20:26:26.414817Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.055152  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327986;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:26.436760Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019522  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327986;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9996;
+# Time: 2025-06-07T20:26:26.491014Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053785  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327986;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:26.512263Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018875  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327986;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9995;
+# Time: 2025-06-07T20:26:26.565516Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052827  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327986;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:26.585978Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018190  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327986;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9994;
+# Time: 2025-06-07T20:26:26.639451Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053064  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327986;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:26.659878Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018071  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327986;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9993;
+# Time: 2025-06-07T20:26:26.713166Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052888  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327986;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:26.733688Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018210  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327986;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9992;
+# Time: 2025-06-07T20:26:26.784439Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050343  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327986;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:26.806989Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017712  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327986;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9991;
+# Time: 2025-06-07T20:26:26.857399Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050054  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327986;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:26.877136Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017515  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327986;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9990;
+# Time: 2025-06-07T20:26:26.928111Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050583  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327986;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:26.947976Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017569  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327986;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9989;
+# Time: 2025-06-07T20:26:26.999034Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050659  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327986;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:27.018871Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017603  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327987;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9988;
+# Time: 2025-06-07T20:26:27.069656Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050343  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327987;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:27.089520Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017735  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327987;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9987;
+# Time: 2025-06-07T20:26:27.140370Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050458  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327987;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:27.160255Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017649  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327987;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9986;
+# Time: 2025-06-07T20:26:27.211268Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050583  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327987;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:27.231279Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017756  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327987;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9985;
+# Time: 2025-06-07T20:26:27.285176Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053376  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327987;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:27.304986Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017578  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327987;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9984;
+# Time: 2025-06-07T20:26:27.356367Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051008  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327987;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:27.376419Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017533  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327987;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9983;
+# Time: 2025-06-07T20:26:27.427495Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050663  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327987;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:27.448729Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018259  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327987;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9982;
+# Time: 2025-06-07T20:26:27.499856Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050651  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327987;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:27.519750Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017601  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327987;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9981;
+# Time: 2025-06-07T20:26:27.578208Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.057958  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327987;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:27.600092Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019655  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327987;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9980;
+# Time: 2025-06-07T20:26:27.655014Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054356  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327987;
+SELECT * FROM `comments` WHERE `post_id` = 9980 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:27.844314Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.033658  Lock_time: 0.000004 Rows_sent: 10002  Rows_examined: 20004
+SET timestamp=1749327987;
+SELECT `id`, `user_id`, `body`, `created_at`, `mime` FROM `posts` ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:27.888843Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016304  Lock_time: 0.000003 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327987;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10024;
+# Time: 2025-06-07T20:26:27.940788Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051438  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100002
+SET timestamp=1749327987;
+SELECT * FROM `comments` WHERE `post_id` = 10024 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:27.958707Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016766  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327987;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10023;
+# Time: 2025-06-07T20:26:28.006957Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.047668  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100002
+SET timestamp=1749327987;
+SELECT * FROM `comments` WHERE `post_id` = 10023 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:28.025016Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016899  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327988;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10000;
+# Time: 2025-06-07T20:26:28.074806Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049279  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327988;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:28.094388Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017342  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327988;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9999;
+# Time: 2025-06-07T20:26:28.143547Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.048782  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327988;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:28.163091Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017320  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327988;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9998;
+# Time: 2025-06-07T20:26:28.213904Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050316  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327988;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:28.233768Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017084  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327988;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9997;
+# Time: 2025-06-07T20:26:28.282983Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.048725  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327988;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:28.302350Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017237  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327988;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9996;
+# Time: 2025-06-07T20:26:28.351776Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049021  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327988;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:28.371069Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017076  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327988;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9995;
+# Time: 2025-06-07T20:26:28.420821Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049333  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327988;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:28.440884Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017755  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327988;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9994;
+# Time: 2025-06-07T20:26:28.491560Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050284  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327988;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:28.511489Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017709  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327988;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9993;
+# Time: 2025-06-07T20:26:28.562809Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050927  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327988;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:28.582856Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017747  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327988;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9992;
+# Time: 2025-06-07T20:26:28.633579Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050321  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327988;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:28.653791Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017935  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327988;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9991;
+# Time: 2025-06-07T20:26:28.703298Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049052  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327988;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:28.722790Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017175  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327988;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9990;
+# Time: 2025-06-07T20:26:28.772301Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049127  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327988;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:28.792099Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017525  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327988;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9989;
+# Time: 2025-06-07T20:26:28.843560Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051054  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327988;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:28.863596Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017742  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327988;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9988;
+# Time: 2025-06-07T20:26:28.917294Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053284  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327988;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:28.938335Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018323  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327988;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9987;
+# Time: 2025-06-07T20:26:28.994355Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.055404  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327988;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:29.017052Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019509  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327988;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9986;
+# Time: 2025-06-07T20:26:29.072104Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054448  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327989;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:29.093767Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018661  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327989;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9985;
+# Time: 2025-06-07T20:26:29.147113Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052797  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327989;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:29.168450Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018364  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327989;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9984;
+# Time: 2025-06-07T20:26:29.221654Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052660  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327989;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:29.242764Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018093  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327989;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9983;
+# Time: 2025-06-07T20:26:29.295418Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052153  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327989;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:29.315470Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017739  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327989;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9982;
+# Time: 2025-06-07T20:26:29.366619Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050795  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327989;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:29.386309Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017489  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327989;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9981;
+# Time: 2025-06-07T20:26:29.437488Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050261  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327989;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:29.555845Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.042204  Lock_time: 0.000003 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327989;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10024;
+# Time: 2025-06-07T20:26:29.613235Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.056963  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100002
+SET timestamp=1749327989;
+SELECT * FROM `comments` WHERE `post_id` = 10024 ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:29.638325Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018444  Lock_time: 0.000003 Rows_sent: 10002  Rows_examined: 20004
+SET timestamp=1749327989;
+SELECT `id`, `user_id`, `body`, `created_at`, `mime` FROM `posts` ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:29.690680Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.022081  Lock_time: 0.000003 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327989;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10024;
+# Time: 2025-06-07T20:26:29.750288Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.059072  Lock_time: 0.000003 Rows_sent: 0  Rows_examined: 100002
+SET timestamp=1749327989;
+SELECT * FROM `comments` WHERE `post_id` = 10024 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:29.771291Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019963  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327989;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10023;
+# Time: 2025-06-07T20:26:29.828929Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.057166  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100002
+SET timestamp=1749327989;
+SELECT * FROM `comments` WHERE `post_id` = 10023 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:29.849218Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019253  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327989;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10000;
+# Time: 2025-06-07T20:26:29.903612Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053978  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327989;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:29.924578Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018612  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327989;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9999;
+# Time: 2025-06-07T20:26:29.979667Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054684  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327989;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:30.000969Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018889  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327989;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9998;
+# Time: 2025-06-07T20:26:30.053462Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052011  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327990;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:30.073972Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018159  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327990;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9997;
+# Time: 2025-06-07T20:26:30.125973Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051613  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327990;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:30.146390Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018105  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327990;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9996;
+# Time: 2025-06-07T20:26:30.197775Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050942  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327990;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:30.217558Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017550  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327990;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9995;
+# Time: 2025-06-07T20:26:30.268237Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050272  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327990;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:30.288195Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017722  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327990;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9994;
+# Time: 2025-06-07T20:26:30.339028Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050433  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327990;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:30.358735Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017594  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327990;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9993;
+# Time: 2025-06-07T20:26:30.409392Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050255  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327990;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:30.429212Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017628  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327990;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9992;
+# Time: 2025-06-07T20:26:30.480184Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050629  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327990;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:30.500281Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017786  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327990;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9991;
+# Time: 2025-06-07T20:26:30.551201Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050564  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327990;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:30.571194Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017671  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327990;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9990;
+# Time: 2025-06-07T20:26:30.621654Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050043  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327990;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:30.641873Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018048  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327990;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9989;
+# Time: 2025-06-07T20:26:30.691631Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049353  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327990;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:30.711430Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017608  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327990;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9988;
+# Time: 2025-06-07T20:26:30.762281Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050368  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327990;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:30.782543Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018038  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327990;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9987;
+# Time: 2025-06-07T20:26:30.833593Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050659  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327990;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:30.853645Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017806  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327990;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9986;
+# Time: 2025-06-07T20:26:30.903741Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049747  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327990;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:30.923154Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017302  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327990;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9985;
+# Time: 2025-06-07T20:26:30.972126Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.048584  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327990;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:30.991448Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017124  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327990;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9984;
+# Time: 2025-06-07T20:26:31.042819Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050979  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327990;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:31.062755Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017601  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327991;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9983;
+# Time: 2025-06-07T20:26:31.113387Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050247  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327991;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:31.133327Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017572  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327991;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9982;
+# Time: 2025-06-07T20:26:31.184642Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050893  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327991;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:31.204401Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017535  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327991;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9981;
+# Time: 2025-06-07T20:26:31.255329Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050529  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327991;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:31.322741Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.020785  Lock_time: 0.000005 Rows_sent: 13  Rows_examined: 10015
+SET timestamp=1749327991;
+SELECT `id`, `user_id`, `body`, `mime`, `created_at` FROM `posts` WHERE `user_id` = 732 ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:31.366246Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.030728  Lock_time: 0.000004 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327991;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9856;
+# Time: 2025-06-07T20:26:31.425965Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.059197  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327991;
+SELECT * FROM `comments` WHERE `post_id` = 9856 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:31.447975Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.020049  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327991;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9403;
+# Time: 2025-06-07T20:26:31.504699Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.056233  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327991;
+SELECT * FROM `comments` WHERE `post_id` = 9403 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:31.526746Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019507  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327991;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9149;
+# Time: 2025-06-07T20:26:31.581291Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054133  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327991;
+SELECT * FROM `comments` WHERE `post_id` = 9149 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:31.602453Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018855  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327991;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 8746;
+# Time: 2025-06-07T20:26:31.657000Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054107  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327991;
+SELECT * FROM `comments` WHERE `post_id` = 8746 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:31.678542Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019092  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327991;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 8016;
+# Time: 2025-06-07T20:26:31.745309Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.066287  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327991;
+SELECT * FROM `comments` WHERE `post_id` = 8016 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:31.773223Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.025037  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327991;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 7648;
+# Time: 2025-06-07T20:26:31.838195Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.064297  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327991;
+SELECT * FROM `comments` WHERE `post_id` = 7648 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:31.862381Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.020898  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327991;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 7213;
+# Time: 2025-06-07T20:26:31.921193Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.058185  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327991;
+SELECT * FROM `comments` WHERE `post_id` = 7213 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:31.944204Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019902  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327991;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 5195;
+# Time: 2025-06-07T20:26:32.000776Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.055975  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327991;
+SELECT * FROM `comments` WHERE `post_id` = 5195 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:32.022616Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019492  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327992;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 3764;
+# Time: 2025-06-07T20:26:32.077674Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054564  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327992;
+SELECT * FROM `comments` WHERE `post_id` = 3764 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:32.099258Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019206  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327992;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 3032;
+# Time: 2025-06-07T20:26:32.152304Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052572  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327992;
+SELECT * FROM `comments` WHERE `post_id` = 3032 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:32.173130Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018466  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327992;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 2365;
+# Time: 2025-06-07T20:26:32.225889Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052346  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327992;
+SELECT * FROM `comments` WHERE `post_id` = 2365 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:32.247259Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019067  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327992;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 1767;
+# Time: 2025-06-07T20:26:32.299811Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052093  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327992;
+SELECT * FROM `comments` WHERE `post_id` = 1767 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:32.320462Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018290  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327992;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 338;
+# Time: 2025-06-07T20:26:32.371163Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050299  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100005
+SET timestamp=1749327992;
+SELECT * FROM `comments` WHERE `post_id` = 338 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:32.391174Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017815  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327992;
+SELECT COUNT(*) AS count FROM `comments` WHERE `user_id` = 732;
+# Time: 2025-06-07T20:26:32.393731Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.002177  Lock_time: 0.000002 Rows_sent: 13  Rows_examined: 10002
+SET timestamp=1749327992;
+SELECT `id` FROM `posts` WHERE `user_id` = 732;
+# Time: 2025-06-07T20:26:32.413568Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019419  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100002
+SET timestamp=1749327992;
+SELECT COUNT(*) AS count FROM `comments` WHERE `post_id` IN (338,1767,2365,3032,3764,5195,7213,7648,8016,8746,9149,9403,9856);
+# Time: 2025-06-07T20:26:32.541257Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017419  Lock_time: 0.000002 Rows_sent: 10002  Rows_examined: 20004
+SET timestamp=1749327992;
+SELECT `id`, `user_id`, `body`, `created_at`, `mime` FROM `posts` ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:32.597222Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019766  Lock_time: 0.000003 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327992;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10024;
+# Time: 2025-06-07T20:26:32.653064Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.055471  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100003
+SET timestamp=1749327992;
+SELECT * FROM `comments` WHERE `post_id` = 10024 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:32.673833Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019500  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327992;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10023;
+# Time: 2025-06-07T20:26:32.728934Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054475  Lock_time: 0.000001 Rows_sent: 0  Rows_examined: 100003
+SET timestamp=1749327992;
+SELECT * FROM `comments` WHERE `post_id` = 10023 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:32.748760Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018726  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327992;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10000;
+# Time: 2025-06-07T20:26:32.802691Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053445  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327992;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:32.824539Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018792  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327992;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9999;
+# Time: 2025-06-07T20:26:32.877401Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052334  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327992;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:32.897986Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018283  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327992;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9998;
+# Time: 2025-06-07T20:26:32.950042Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051620  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327992;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:32.970516Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018203  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327992;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9997;
+# Time: 2025-06-07T20:26:33.023039Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051952  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327992;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:33.043406Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018066  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327993;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9996;
+# Time: 2025-06-07T20:26:33.095264Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051436  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327993;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:33.115219Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017637  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327993;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9995;
+# Time: 2025-06-07T20:26:33.166199Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050553  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327993;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:33.186725Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018319  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327993;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9994;
+# Time: 2025-06-07T20:26:33.238785Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051558  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327993;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:33.258603Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017544  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327993;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9993;
+# Time: 2025-06-07T20:26:33.310026Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050846  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327993;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:33.330332Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017683  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327993;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9992;
+# Time: 2025-06-07T20:26:33.381295Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050488  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327993;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:33.401112Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017609  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327993;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9991;
+# Time: 2025-06-07T20:26:33.451720Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050209  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327993;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:33.471893Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017915  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327993;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9990;
+# Time: 2025-06-07T20:26:33.522919Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050598  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327993;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:33.542783Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017602  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327993;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9989;
+# Time: 2025-06-07T20:26:33.593446Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050315  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327993;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:33.613969Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017948  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327993;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9988;
+# Time: 2025-06-07T20:26:33.665374Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050956  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327993;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:33.685914Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017716  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327993;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9987;
+# Time: 2025-06-07T20:26:33.736763Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050331  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327993;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:33.756066Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017085  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327993;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9986;
+# Time: 2025-06-07T20:26:33.805556Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049123  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327993;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:33.827387Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019375  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327993;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9985;
+# Time: 2025-06-07T20:26:33.882515Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054642  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327993;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:33.904071Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019093  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327993;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9984;
+# Time: 2025-06-07T20:26:33.958934Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054315  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327993;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:33.980788Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018770  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327993;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9983;
+# Time: 2025-06-07T20:26:34.035893Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054602  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327993;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:34.056481Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018191  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327994;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9982;
+# Time: 2025-06-07T20:26:34.108375Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051495  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327994;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:34.129911Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019096  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327994;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9981;
+# Time: 2025-06-07T20:26:34.183108Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052718  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327994;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:34.286800Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052012  Lock_time: 0.000003 Rows_sent: 10002  Rows_examined: 20004
+SET timestamp=1749327994;
+SELECT `id`, `user_id`, `body`, `created_at`, `mime` FROM `posts` ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:34.336108Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.021153  Lock_time: 0.000003 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327994;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10024;
+# Time: 2025-06-07T20:26:34.394561Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.058106  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100003
+SET timestamp=1749327994;
+SELECT * FROM `comments` WHERE `post_id` = 10024 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:34.415776Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.020186  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327994;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10023;
+# Time: 2025-06-07T20:26:34.473235Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.056942  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100003
+SET timestamp=1749327994;
+SELECT * FROM `comments` WHERE `post_id` = 10023 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:34.493818Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019479  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327994;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10000;
+# Time: 2025-06-07T20:26:34.552258Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.057949  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327994;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:34.575520Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.020262  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327994;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9999;
+# Time: 2025-06-07T20:26:34.633769Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.057680  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327994;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:34.656491Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.020169  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327994;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9998;
+# Time: 2025-06-07T20:26:34.712016Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.055053  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327994;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:34.733405Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018977  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327994;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9997;
+# Time: 2025-06-07T20:26:34.787761Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053865  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327994;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:34.808780Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018671  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327994;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9996;
+# Time: 2025-06-07T20:26:34.862149Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052787  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327994;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:34.883223Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018152  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327994;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9995;
+# Time: 2025-06-07T20:26:34.936348Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052640  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327994;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:34.957209Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018574  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327994;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9994;
+# Time: 2025-06-07T20:26:35.009355Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051690  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327994;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:35.029289Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017693  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327995;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9993;
+# Time: 2025-06-07T20:26:35.080199Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050477  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327995;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:35.100068Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017561  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327995;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9992;
+# Time: 2025-06-07T20:26:35.151231Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050780  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327995;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:35.171194Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017627  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327995;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9991;
+# Time: 2025-06-07T20:26:35.221885Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050280  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327995;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:35.241668Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017539  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327995;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9990;
+# Time: 2025-06-07T20:26:35.292406Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050341  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327995;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:35.312561Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017669  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327995;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9989;
+# Time: 2025-06-07T20:26:35.363480Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050429  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327995;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:35.383221Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017549  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327995;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9988;
+# Time: 2025-06-07T20:26:35.434862Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051240  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327995;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:35.454601Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017591  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327995;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9987;
+# Time: 2025-06-07T20:26:35.505564Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050552  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327995;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:35.525226Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017482  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327995;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9986;
+# Time: 2025-06-07T20:26:35.576588Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051028  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327995;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:35.596310Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017482  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327995;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9985;
+# Time: 2025-06-07T20:26:35.646083Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049383  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327995;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:35.665841Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017597  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327995;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9984;
+# Time: 2025-06-07T20:26:35.715602Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049339  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327995;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:35.735072Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017166  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327995;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9983;
+# Time: 2025-06-07T20:26:35.784331Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.048830  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327995;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:35.803791Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017293  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327995;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9982;
+# Time: 2025-06-07T20:26:35.854791Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050646  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327995;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:35.875148Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017704  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327995;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9981;
+# Time: 2025-06-07T20:26:35.933853Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.058353  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327995;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:35.970671Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.022463  Lock_time: 0.000005 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327995;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9856;
+# Time: 2025-06-07T20:26:36.024937Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053763  Lock_time: 0.000003 Rows_sent: 9  Rows_examined: 100012
+SET timestamp=1749327995;
+SELECT * FROM `comments` WHERE `post_id` = 9856 ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:36.177489Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050858  Lock_time: 0.000003 Rows_sent: 10002  Rows_examined: 20004
+SET timestamp=1749327996;
+SELECT `id`, `user_id`, `body`, `created_at`, `mime` FROM `posts` ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:36.233086Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.021869  Lock_time: 0.000003 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327996;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10024;
+# Time: 2025-06-07T20:26:36.293937Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.060457  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100003
+SET timestamp=1749327996;
+SELECT * FROM `comments` WHERE `post_id` = 10024 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:36.315281Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.020255  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327996;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10023;
+# Time: 2025-06-07T20:26:36.373719Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.058033  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100003
+SET timestamp=1749327996;
+SELECT * FROM `comments` WHERE `post_id` = 10023 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:36.394594Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019772  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327996;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10000;
+# Time: 2025-06-07T20:26:36.450817Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.055837  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327996;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:36.472956Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019052  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327996;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9999;
+# Time: 2025-06-07T20:26:36.527329Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053899  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327996;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:36.548402Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018650  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327996;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9998;
+# Time: 2025-06-07T20:26:36.601017Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052185  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327996;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:36.621471Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018224  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327996;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9997;
+# Time: 2025-06-07T20:26:36.674328Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052497  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327996;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:36.694960Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018242  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327996;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9996;
+# Time: 2025-06-07T20:26:36.747261Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051863  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327996;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:36.768600Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018414  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327996;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9995;
+# Time: 2025-06-07T20:26:36.821312Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052069  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327996;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:36.841249Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017658  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327996;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9994;
+# Time: 2025-06-07T20:26:36.891901Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050160  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327996;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:36.911843Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017680  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327996;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9993;
+# Time: 2025-06-07T20:26:36.962454Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050200  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327996;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:36.982226Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017549  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327996;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9992;
+# Time: 2025-06-07T20:26:37.032711Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050084  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327996;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:37.052589Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017622  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327997;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9991;
+# Time: 2025-06-07T20:26:37.104027Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051040  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327997;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:37.123941Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017646  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327997;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9990;
+# Time: 2025-06-07T20:26:37.175191Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050833  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327997;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:37.195578Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017927  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327997;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9989;
+# Time: 2025-06-07T20:26:37.246416Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050345  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327997;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:37.266894Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017619  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327997;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9988;
+# Time: 2025-06-07T20:26:37.319177Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051730  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327997;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:37.339483Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018280  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327997;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9987;
+# Time: 2025-06-07T20:26:37.394668Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054601  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327997;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:37.416017Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019008  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327997;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9986;
+# Time: 2025-06-07T20:26:37.470301Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053862  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327997;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:37.490683Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018119  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327997;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9985;
+# Time: 2025-06-07T20:26:37.542872Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051821  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327997;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:37.563310Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018176  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327997;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9984;
+# Time: 2025-06-07T20:26:37.615825Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052104  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327997;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:37.636645Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018476  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327997;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9983;
+# Time: 2025-06-07T20:26:37.687829Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050794  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327997;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:37.708422Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017701  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327997;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9982;
+# Time: 2025-06-07T20:26:37.759389Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050417  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327997;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:37.780505Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018199  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327997;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9981;
+# Time: 2025-06-07T20:26:37.831751Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050711  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327997;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:37.919722Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.022254  Lock_time: 0.000002 Rows_sent: 10002  Rows_examined: 20004
+SET timestamp=1749327997;
+SELECT `id`, `user_id`, `body`, `created_at`, `mime` FROM `posts` ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:37.968365Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019423  Lock_time: 0.000003 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327997;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10024;
+# Time: 2025-06-07T20:26:38.027177Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.058139  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100003
+SET timestamp=1749327997;
+SELECT * FROM `comments` WHERE `post_id` = 10024 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:38.049849Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.021313  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327998;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10023;
+# Time: 2025-06-07T20:26:38.108932Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.058497  Lock_time: 0.000003 Rows_sent: 0  Rows_examined: 100003
+SET timestamp=1749327998;
+SELECT * FROM `comments` WHERE `post_id` = 10023 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:38.130173Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019965  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327998;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10000;
+# Time: 2025-06-07T20:26:38.186072Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.055272  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327998;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:38.208329Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019269  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327998;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9999;
+# Time: 2025-06-07T20:26:38.263055Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054174  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327998;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:38.284379Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018965  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327998;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9998;
+# Time: 2025-06-07T20:26:38.337424Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052592  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327998;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:38.357914Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018136  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327998;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9997;
+# Time: 2025-06-07T20:26:38.410245Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051961  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327998;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:38.430784Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018249  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327998;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9996;
+# Time: 2025-06-07T20:26:38.482319Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051122  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327998;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:38.502091Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017557  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327998;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9995;
+# Time: 2025-06-07T20:26:38.552839Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050350  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327998;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:38.572682Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017703  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327998;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9994;
+# Time: 2025-06-07T20:26:38.623289Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050207  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327998;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:38.643423Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017864  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327998;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9993;
+# Time: 2025-06-07T20:26:38.694028Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050197  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327998;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:38.713831Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017621  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327998;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9992;
+# Time: 2025-06-07T20:26:38.764777Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050511  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327998;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:38.784567Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017554  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327998;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9991;
+# Time: 2025-06-07T20:26:38.834289Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049321  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327998;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:38.856652Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017207  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327998;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9990;
+# Time: 2025-06-07T20:26:38.906885Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049750  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327998;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:38.927154Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017939  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327998;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9989;
+# Time: 2025-06-07T20:26:38.978429Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050842  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327998;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:38.998347Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017643  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327998;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9988;
+# Time: 2025-06-07T20:26:39.049025Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050203  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327998;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:39.069610Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018097  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327999;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9987;
+# Time: 2025-06-07T20:26:39.120224Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050162  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327999;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:39.140361Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017831  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327999;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9986;
+# Time: 2025-06-07T20:26:39.191636Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050792  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327999;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:39.211501Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017628  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327999;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9985;
+# Time: 2025-06-07T20:26:39.262119Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050219  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327999;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:39.282217Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017800  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327999;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9984;
+# Time: 2025-06-07T20:26:39.333379Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050762  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327999;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:39.353343Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017694  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327999;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9983;
+# Time: 2025-06-07T20:26:39.404103Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050362  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327999;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:39.423990Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017579  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327999;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9982;
+# Time: 2025-06-07T20:26:39.474943Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050541  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327999;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:39.494878Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017585  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327999;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9981;
+# Time: 2025-06-07T20:26:39.545462Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050199  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327999;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:39.584721Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019544  Lock_time: 0.000002 Rows_sent: 10002  Rows_examined: 20004
+SET timestamp=1749327999;
+SELECT `id`, `user_id`, `body`, `created_at`, `mime` FROM `posts` ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:39.626419Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018917  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327999;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10024;
+# Time: 2025-06-07T20:26:39.679199Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052248  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100003
+SET timestamp=1749327999;
+SELECT * FROM `comments` WHERE `post_id` = 10024 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:39.699036Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018639  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327999;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10023;
+# Time: 2025-06-07T20:26:39.751395Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051855  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100003
+SET timestamp=1749327999;
+SELECT * FROM `comments` WHERE `post_id` = 10023 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:39.770097Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017742  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327999;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10000;
+# Time: 2025-06-07T20:26:39.821545Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051026  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327999;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:39.841490Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017670  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327999;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9999;
+# Time: 2025-06-07T20:26:39.892210Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050265  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327999;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:39.912875Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017747  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327999;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9998;
+# Time: 2025-06-07T20:26:39.964379Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050969  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327999;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:39.984892Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017613  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749327999;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9997;
+# Time: 2025-06-07T20:26:40.036818Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051415  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749327999;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:40.059073Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018103  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749328000;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9996;
+# Time: 2025-06-07T20:26:40.119090Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.059452  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749328000;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:40.144030Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.022254  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749328000;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9995;
+# Time: 2025-06-07T20:26:40.205743Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.061167  Lock_time: 0.000005 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749328000;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:40.229199Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.020125  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749328000;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9994;
+# Time: 2025-06-07T20:26:40.285461Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.055712  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749328000;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:40.307880Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019312  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749328000;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9993;
+# Time: 2025-06-07T20:26:40.363491Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.055073  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749328000;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:40.384553Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018654  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749328000;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9992;
+# Time: 2025-06-07T20:26:40.438271Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053300  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749328000;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:40.459226Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018524  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749328000;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9991;
+# Time: 2025-06-07T20:26:40.512230Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052582  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749328000;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:40.539193Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.022536  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749328000;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9990;
+# Time: 2025-06-07T20:26:40.589558Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049900  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749328000;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:40.609472Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017725  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749328000;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9989;
+# Time: 2025-06-07T20:26:40.660508Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050649  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749328000;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:40.680569Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017589  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749328000;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9988;
+# Time: 2025-06-07T20:26:40.731335Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050367  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749328000;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:40.751216Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017692  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749328000;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9987;
+# Time: 2025-06-07T20:26:40.801963Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050364  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749328000;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:40.821869Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017631  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749328000;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9986;
+# Time: 2025-06-07T20:26:40.872623Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050363  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749328000;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:40.892132Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017341  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749328000;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9985;
+# Time: 2025-06-07T20:26:40.941662Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049141  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749328000;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:40.961292Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017400  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749328000;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9984;
+# Time: 2025-06-07T20:26:41.010956Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049282  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749328000;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:41.031111Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017921  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749328001;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9983;
+# Time: 2025-06-07T20:26:41.082675Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051102  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749328001;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:41.102929Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018020  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749328001;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9982;
+# Time: 2025-06-07T20:26:41.153794Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050456  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749328001;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:41.173742Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017635  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749328001;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9981;
+# Time: 2025-06-07T20:26:41.224717Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050498  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749328001;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:41.267600Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.028132  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749328001;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 8057;
+# Time: 2025-06-07T20:26:41.322623Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054541  Lock_time: 0.000002 Rows_sent: 10  Rows_examined: 100013
+SET timestamp=1749328001;
+SELECT * FROM `comments` WHERE `post_id` = 8057 ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:41.348358Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.008406  Lock_time: 0.000003 Rows_sent: 12  Rows_examined: 10014
+SET timestamp=1749328001;
+SELECT `id`, `user_id`, `body`, `mime`, `created_at` FROM `posts` WHERE `user_id` = 104 ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:41.368020Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019048  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749328001;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 8213;
+# Time: 2025-06-07T20:26:41.422789Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054225  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749328001;
+SELECT * FROM `comments` WHERE `post_id` = 8213 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:41.445012Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019169  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749328001;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 8019;
+# Time: 2025-06-07T20:26:41.498561Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053011  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749328001;
+SELECT * FROM `comments` WHERE `post_id` = 8019 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:41.520130Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018674  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749328001;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 7338;
+# Time: 2025-06-07T20:26:41.573162Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052497  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749328001;
+SELECT * FROM `comments` WHERE `post_id` = 7338 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:41.594201Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018736  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749328001;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 7183;
+# Time: 2025-06-07T20:26:41.645932Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051137  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749328001;
+SELECT * FROM `comments` WHERE `post_id` = 7183 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:41.666380Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018136  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749328001;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 7097;
+# Time: 2025-06-07T20:26:41.718712Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051938  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749328001;
+SELECT * FROM `comments` WHERE `post_id` = 7097 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:41.739038Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018071  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749328001;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 6560;
+# Time: 2025-06-07T20:26:41.790917Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051459  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749328001;
+SELECT * FROM `comments` WHERE `post_id` = 6560 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:41.811332Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018157  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749328001;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 5901;
+# Time: 2025-06-07T20:26:41.863031Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051295  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749328001;
+SELECT * FROM `comments` WHERE `post_id` = 5901 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:41.883322Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018063  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749328001;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 4919;
+# Time: 2025-06-07T20:26:41.935336Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051617  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749328001;
+SELECT * FROM `comments` WHERE `post_id` = 4919 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:41.955674Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018045  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749328001;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 3274;
+# Time: 2025-06-07T20:26:42.006919Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050828  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749328001;
+SELECT * FROM `comments` WHERE `post_id` = 3274 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:42.027347Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018238  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749328002;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 2647;
+# Time: 2025-06-07T20:26:42.078319Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050567  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749328002;
+SELECT * FROM `comments` WHERE `post_id` = 2647 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:42.098158Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017672  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749328002;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 1635;
+# Time: 2025-06-07T20:26:42.149476Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051023  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749328002;
+SELECT * FROM `comments` WHERE `post_id` = 1635 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:42.169392Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017621  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749328002;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 878;
+# Time: 2025-06-07T20:26:42.225485Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.055687  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100006
+SET timestamp=1749328002;
+SELECT * FROM `comments` WHERE `post_id` = 878 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:42.248831Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.020918  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749328002;
+SELECT COUNT(*) AS count FROM `comments` WHERE `user_id` = 104;
+# Time: 2025-06-07T20:26:42.253400Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.004027  Lock_time: 0.000002 Rows_sent: 12  Rows_examined: 10002
+SET timestamp=1749328002;
+SELECT `id` FROM `posts` WHERE `user_id` = 104;
+# Time: 2025-06-07T20:26:42.274605Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.020670  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100003
+SET timestamp=1749328002;
+SELECT COUNT(*) AS count FROM `comments` WHERE `post_id` IN (878,1635,2647,3274,4919,5901,6560,7097,7183,7338,8019,8213);
+# Time: 2025-06-07T20:26:42.399840Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.023218  Lock_time: 0.000003 Rows_sent: 10003  Rows_examined: 20006
+SET timestamp=1749328002;
+SELECT `id`, `user_id`, `body`, `created_at`, `mime` FROM `posts` ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:42.455270Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.020101  Lock_time: 0.000003 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328002;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10025;
+# Time: 2025-06-07T20:26:42.512901Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.057099  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100004
+SET timestamp=1749328002;
+SELECT * FROM `comments` WHERE `post_id` = 10025 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:42.533941Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.020065  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328002;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10024;
+# Time: 2025-06-07T20:26:42.589492Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.055102  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100004
+SET timestamp=1749328002;
+SELECT * FROM `comments` WHERE `post_id` = 10024 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:42.609328Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018875  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328002;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10023;
+# Time: 2025-06-07T20:26:42.663051Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053252  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100004
+SET timestamp=1749328002;
+SELECT * FROM `comments` WHERE `post_id` = 10023 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:42.682711Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018717  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328002;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10000;
+# Time: 2025-06-07T20:26:42.736246Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053055  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328002;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:42.756869Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018265  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328002;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9999;
+# Time: 2025-06-07T20:26:42.808998Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051722  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328002;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:42.830481Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019039  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328002;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9998;
+# Time: 2025-06-07T20:26:42.887962Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.057027  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328002;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:42.909315Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019057  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328002;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9997;
+# Time: 2025-06-07T20:26:42.965242Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.055424  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328002;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:42.987438Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019413  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328002;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9996;
+# Time: 2025-06-07T20:26:43.042918Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054956  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328002;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:43.064779Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018724  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328003;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9995;
+# Time: 2025-06-07T20:26:43.119093Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053782  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328003;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:43.140363Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018697  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328003;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9994;
+# Time: 2025-06-07T20:26:43.193341Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052498  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328003;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:43.214147Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018532  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328003;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9993;
+# Time: 2025-06-07T20:26:43.266853Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052225  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328003;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:43.287292Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018103  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328003;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9992;
+# Time: 2025-06-07T20:26:43.338871Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051170  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328003;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:43.358978Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017614  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328003;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9991;
+# Time: 2025-06-07T20:26:43.409355Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049969  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328003;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:43.429020Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017504  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328003;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9990;
+# Time: 2025-06-07T20:26:43.480006Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050596  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328003;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:43.499942Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017633  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328003;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9989;
+# Time: 2025-06-07T20:26:43.550550Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050223  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328003;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:43.570275Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017548  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328003;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9988;
+# Time: 2025-06-07T20:26:43.621133Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050510  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328003;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:43.640823Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017494  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328003;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9987;
+# Time: 2025-06-07T20:26:43.691234Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050014  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328003;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:43.710562Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017188  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328003;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9986;
+# Time: 2025-06-07T20:26:43.761269Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050228  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328003;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:43.781518Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017914  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328003;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9985;
+# Time: 2025-06-07T20:26:43.832064Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050108  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328003;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:43.851896Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017596  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328003;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9984;
+# Time: 2025-06-07T20:26:43.903116Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050737  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328003;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:43.923253Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017652  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328003;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9983;
+# Time: 2025-06-07T20:26:43.973620Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049961  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328003;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:43.994074Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018219  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328003;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9982;
+# Time: 2025-06-07T20:26:44.044856Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050311  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328003;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:44.071980Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018962  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328004;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9995;
+# Time: 2025-06-07T20:26:44.122598Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050124  Lock_time: 0.000002 Rows_sent: 6  Rows_examined: 100010
+SET timestamp=1749328004;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:44.147401Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017632  Lock_time: 0.000003 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328004;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10025;
+# Time: 2025-06-07T20:26:44.197934Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050062  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100004
+SET timestamp=1749328004;
+SELECT * FROM `comments` WHERE `post_id` = 10025 ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:44.237657Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.021077  Lock_time: 0.000003 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328004;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 8213;
+# Time: 2025-06-07T20:26:44.292884Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054713  Lock_time: 0.000002 Rows_sent: 8  Rows_examined: 100012
+SET timestamp=1749328004;
+SELECT * FROM `comments` WHERE `post_id` = 8213 ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:44.462665Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.034814  Lock_time: 0.000004 Rows_sent: 10003  Rows_examined: 20006
+SET timestamp=1749328004;
+SELECT `id`, `user_id`, `body`, `created_at`, `mime` FROM `posts` ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:44.515105Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.020279  Lock_time: 0.000004 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328004;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10025;
+# Time: 2025-06-07T20:26:44.571860Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.056388  Lock_time: 0.000001 Rows_sent: 0  Rows_examined: 100004
+SET timestamp=1749328004;
+SELECT * FROM `comments` WHERE `post_id` = 10025 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:44.593040Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.020141  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328004;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10024;
+# Time: 2025-06-07T20:26:44.647515Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054008  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100004
+SET timestamp=1749328004;
+SELECT * FROM `comments` WHERE `post_id` = 10024 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:44.667585Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019024  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328004;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10023;
+# Time: 2025-06-07T20:26:44.721721Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053533  Lock_time: 0.000003 Rows_sent: 0  Rows_examined: 100004
+SET timestamp=1749328004;
+SELECT * FROM `comments` WHERE `post_id` = 10023 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:44.741606Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018816  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328004;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10000;
+# Time: 2025-06-07T20:26:44.796054Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053846  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328004;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:44.817412Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018969  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328004;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9999;
+# Time: 2025-06-07T20:26:44.869899Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052076  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328004;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:44.890494Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018126  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328004;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9998;
+# Time: 2025-06-07T20:26:44.942746Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051787  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328004;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:44.963415Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018330  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328004;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9997;
+# Time: 2025-06-07T20:26:45.016349Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052523  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328004;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:45.036260Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017619  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328005;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9996;
+# Time: 2025-06-07T20:26:45.086981Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050399  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328005;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:45.107146Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017823  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328005;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9995;
+# Time: 2025-06-07T20:26:45.158031Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050554  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328005;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:45.178016Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017579  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328005;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9994;
+# Time: 2025-06-07T20:26:45.228340Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049918  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328005;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:45.248154Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017608  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328005;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9993;
+# Time: 2025-06-07T20:26:45.298655Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050061  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328005;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:45.318437Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017530  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328005;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9992;
+# Time: 2025-06-07T20:26:45.369050Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050213  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328005;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:45.389548Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017639  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328005;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9991;
+# Time: 2025-06-07T20:26:45.439676Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049634  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328005;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:45.459469Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017537  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328005;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9990;
+# Time: 2025-06-07T20:26:45.509052Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049190  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328005;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:45.528983Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017666  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328005;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9989;
+# Time: 2025-06-07T20:26:45.579578Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050209  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328005;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:45.599671Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017914  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328005;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9988;
+# Time: 2025-06-07T20:26:45.651373Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051357  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328005;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:45.674305Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.020091  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328005;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9987;
+# Time: 2025-06-07T20:26:45.733925Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.059161  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328005;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:45.755179Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018791  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328005;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9986;
+# Time: 2025-06-07T20:26:45.809327Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053648  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328005;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:45.829804Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018179  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328005;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9985;
+# Time: 2025-06-07T20:26:45.882786Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052554  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328005;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:45.903510Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018206  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328005;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9984;
+# Time: 2025-06-07T20:26:45.955545Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051623  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328005;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:45.975889Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018007  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328005;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9983;
+# Time: 2025-06-07T20:26:46.026877Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050526  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328005;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:46.046721Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017573  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328006;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9982;
+# Time: 2025-06-07T20:26:46.097314Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050203  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328006;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:46.165234Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.029408  Lock_time: 0.000003 Rows_sent: 10003  Rows_examined: 20006
+SET timestamp=1749328006;
+SELECT `id`, `user_id`, `body`, `created_at`, `mime` FROM `posts` ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:46.216121Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019237  Lock_time: 0.000003 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328006;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10025;
+# Time: 2025-06-07T20:26:46.270001Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053353  Lock_time: 0.000001 Rows_sent: 0  Rows_examined: 100004
+SET timestamp=1749328006;
+SELECT * FROM `comments` WHERE `post_id` = 10025 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:46.289849Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018843  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328006;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10024;
+# Time: 2025-06-07T20:26:46.343755Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053448  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100004
+SET timestamp=1749328006;
+SELECT * FROM `comments` WHERE `post_id` = 10024 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:46.362918Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018178  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328006;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10023;
+# Time: 2025-06-07T20:26:46.416384Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053047  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100004
+SET timestamp=1749328006;
+SELECT * FROM `comments` WHERE `post_id` = 10023 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:46.436685Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019235  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328006;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10000;
+# Time: 2025-06-07T20:26:46.493298Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.056069  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328006;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:46.515317Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019484  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328006;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9999;
+# Time: 2025-06-07T20:26:46.569208Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053483  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328006;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:46.590208Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018596  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328006;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9998;
+# Time: 2025-06-07T20:26:46.643432Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052804  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328006;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:46.664060Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018307  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328006;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9997;
+# Time: 2025-06-07T20:26:46.716121Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051638  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328006;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:46.736551Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018129  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328006;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9996;
+# Time: 2025-06-07T20:26:46.788869Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051888  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328006;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:46.810081Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018574  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328006;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9995;
+# Time: 2025-06-07T20:26:46.861321Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050831  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328006;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:46.881109Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017559  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328006;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9994;
+# Time: 2025-06-07T20:26:46.931943Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050422  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328006;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:46.951913Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017617  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328006;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9993;
+# Time: 2025-06-07T20:26:47.002562Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050244  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328006;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:47.022550Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017708  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328007;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9992;
+# Time: 2025-06-07T20:26:47.073277Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050308  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328007;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:47.093616Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017724  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328007;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9991;
+# Time: 2025-06-07T20:26:47.144163Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050079  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328007;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:47.164177Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017752  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328007;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9990;
+# Time: 2025-06-07T20:26:47.214576Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049998  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328007;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:47.234706Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017883  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328007;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9989;
+# Time: 2025-06-07T20:26:47.285488Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050358  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328007;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:47.305479Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017678  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328007;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9988;
+# Time: 2025-06-07T20:26:47.356167Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050269  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328007;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:47.376016Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017612  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328007;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9987;
+# Time: 2025-06-07T20:26:47.426923Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050499  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328007;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:47.446881Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017636  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328007;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9986;
+# Time: 2025-06-07T20:26:47.497732Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050373  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328007;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:47.517669Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017641  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328007;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9985;
+# Time: 2025-06-07T20:26:47.568421Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050332  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328007;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:47.588352Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017583  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328007;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9984;
+# Time: 2025-06-07T20:26:47.637969Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049201  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328007;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:47.657342Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017078  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328007;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9983;
+# Time: 2025-06-07T20:26:47.706506Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.048749  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328007;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:47.725698Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017075  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328007;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9982;
+# Time: 2025-06-07T20:26:47.774725Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.048633  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328007;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:47.824800Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.022498  Lock_time: 0.000003 Rows_sent: 10003  Rows_examined: 20006
+SET timestamp=1749328007;
+SELECT `id`, `user_id`, `body`, `created_at`, `mime` FROM `posts` ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:47.868400Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018847  Lock_time: 0.000004 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328007;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10025;
+# Time: 2025-06-07T20:26:47.922699Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053844  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100004
+SET timestamp=1749328007;
+SELECT * FROM `comments` WHERE `post_id` = 10025 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:47.942892Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018960  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328007;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10024;
+# Time: 2025-06-07T20:26:47.995557Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052098  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100004
+SET timestamp=1749328007;
+SELECT * FROM `comments` WHERE `post_id` = 10024 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:48.015071Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018277  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328007;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10023;
+# Time: 2025-06-07T20:26:48.068548Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052974  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100004
+SET timestamp=1749328008;
+SELECT * FROM `comments` WHERE `post_id` = 10023 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:48.087861Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018250  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328008;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10000;
+# Time: 2025-06-07T20:26:48.140155Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051882  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328008;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:48.160405Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017712  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328008;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9999;
+# Time: 2025-06-07T20:26:48.212007Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051104  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328008;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:48.231928Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017692  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328008;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9998;
+# Time: 2025-06-07T20:26:48.282525Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050165  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328008;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:48.302435Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017584  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328008;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9997;
+# Time: 2025-06-07T20:26:48.353067Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050188  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328008;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:48.372799Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017500  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328008;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9996;
+# Time: 2025-06-07T20:26:48.423532Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050337  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328008;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:48.444863Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018153  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328008;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9995;
+# Time: 2025-06-07T20:26:48.502760Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.057480  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328008;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:48.529180Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.023000  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328008;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9994;
+# Time: 2025-06-07T20:26:48.588246Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.058421  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328008;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:48.611923Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.020406  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328008;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9993;
+# Time: 2025-06-07T20:26:48.668057Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.055540  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328008;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:48.690688Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.020138  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328008;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9992;
+# Time: 2025-06-07T20:26:48.744834Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053695  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328008;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:48.766190Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019009  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328008;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9991;
+# Time: 2025-06-07T20:26:48.820141Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053417  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328008;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:48.840704Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018187  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328008;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9990;
+# Time: 2025-06-07T20:26:48.892596Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051541  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328008;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:48.913337Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018452  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328008;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9989;
+# Time: 2025-06-07T20:26:48.965586Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051806  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328008;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:48.986262Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018324  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328008;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9988;
+# Time: 2025-06-07T20:26:49.036944Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050318  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328008;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:49.056825Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017560  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328009;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9987;
+# Time: 2025-06-07T20:26:49.107643Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050419  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328009;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:49.127616Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017557  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328009;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9986;
+# Time: 2025-06-07T20:26:49.178375Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050301  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328009;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:49.198560Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017961  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328009;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9985;
+# Time: 2025-06-07T20:26:49.249302Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050332  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328009;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:49.269374Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017641  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328009;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9984;
+# Time: 2025-06-07T20:26:49.321140Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051306  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328009;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:49.341166Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017747  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328009;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9983;
+# Time: 2025-06-07T20:26:49.391882Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050256  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328009;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:49.411683Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017563  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328009;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9982;
+# Time: 2025-06-07T20:26:49.462313Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050235  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328009;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:49.502853Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.014932  Lock_time: 0.000003 Rows_sent: 8  Rows_examined: 10011
+SET timestamp=1749328009;
+SELECT `id`, `user_id`, `body`, `mime`, `created_at` FROM `posts` WHERE `user_id` = 892 ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:49.530394Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.026887  Lock_time: 0.000034 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328009;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 7762;
+# Time: 2025-06-07T20:26:49.586655Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.055734  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328009;
+SELECT * FROM `comments` WHERE `post_id` = 7762 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:49.608264Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019182  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328009;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 7499;
+# Time: 2025-06-07T20:26:49.662617Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053921  Lock_time: 0.000044 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328009;
+SELECT * FROM `comments` WHERE `post_id` = 7499 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:49.684086Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019060  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328009;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 7060;
+# Time: 2025-06-07T20:26:49.737210Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052694  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328009;
+SELECT * FROM `comments` WHERE `post_id` = 7060 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:49.757907Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018413  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328009;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 7032;
+# Time: 2025-06-07T20:26:49.811028Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052703  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328009;
+SELECT * FROM `comments` WHERE `post_id` = 7032 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:49.831949Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018488  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328009;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 6595;
+# Time: 2025-06-07T20:26:49.884665Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052277  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328009;
+SELECT * FROM `comments` WHERE `post_id` = 6595 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:49.904922Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017922  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328009;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 3162;
+# Time: 2025-06-07T20:26:49.956239Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050870  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328009;
+SELECT * FROM `comments` WHERE `post_id` = 3162 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:49.976441Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017923  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328009;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 2787;
+# Time: 2025-06-07T20:26:50.028483Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051642  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328009;
+SELECT * FROM `comments` WHERE `post_id` = 2787 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:50.048498Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017592  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328010;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 887;
+# Time: 2025-06-07T20:26:50.099839Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050930  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328010;
+SELECT * FROM `comments` WHERE `post_id` = 887 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:50.119793Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017683  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328010;
+SELECT COUNT(*) AS count FROM `comments` WHERE `user_id` = 892;
+# Time: 2025-06-07T20:26:50.122313Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.002151  Lock_time: 0.000001 Rows_sent: 8  Rows_examined: 10003
+SET timestamp=1749328010;
+SELECT `id` FROM `posts` WHERE `user_id` = 892;
+# Time: 2025-06-07T20:26:50.141555Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018872  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328010;
+SELECT COUNT(*) AS count FROM `comments` WHERE `post_id` IN (887,2787,3162,6595,7032,7060,7499,7762);
+# Time: 2025-06-07T20:26:50.186316Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.007915  Lock_time: 0.000003 Rows_sent: 9  Rows_examined: 10012
+SET timestamp=1749328010;
+SELECT `id`, `user_id`, `body`, `mime`, `created_at` FROM `posts` WHERE `user_id` = 75 ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:50.205766Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018888  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328010;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 7358;
+# Time: 2025-06-07T20:26:50.259073Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052861  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328010;
+SELECT * FROM `comments` WHERE `post_id` = 7358 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:50.280297Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018670  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328010;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 6968;
+# Time: 2025-06-07T20:26:50.332432Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051685  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328010;
+SELECT * FROM `comments` WHERE `post_id` = 6968 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:50.353032Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018351  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328010;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 4659;
+# Time: 2025-06-07T20:26:50.404617Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051104  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328010;
+SELECT * FROM `comments` WHERE `post_id` = 4659 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:50.425356Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018300  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328010;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 3766;
+# Time: 2025-06-07T20:26:50.477086Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051212  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328010;
+SELECT * FROM `comments` WHERE `post_id` = 3766 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:50.497438Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018079  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328010;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 3682;
+# Time: 2025-06-07T20:26:50.548988Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051113  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328010;
+SELECT * FROM `comments` WHERE `post_id` = 3682 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:50.569245Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017989  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328010;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 3358;
+# Time: 2025-06-07T20:26:50.633500Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.063813  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328010;
+SELECT * FROM `comments` WHERE `post_id` = 3358 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:50.655990Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019775  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328010;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 2738;
+# Time: 2025-06-07T20:26:50.710412Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053899  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328010;
+SELECT * FROM `comments` WHERE `post_id` = 2738 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:50.731404Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018611  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328010;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 847;
+# Time: 2025-06-07T20:26:50.783750Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051961  Lock_time: 0.000002 Rows_sent: 2  Rows_examined: 100006
+SET timestamp=1749328010;
+SELECT * FROM `comments` WHERE `post_id` = 847 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:50.804188Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018633  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328010;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 465;
+# Time: 2025-06-07T20:26:50.856313Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051741  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100007
+SET timestamp=1749328010;
+SELECT * FROM `comments` WHERE `post_id` = 465 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:50.877278Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018220  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328010;
+SELECT COUNT(*) AS count FROM `comments` WHERE `user_id` = 75;
+# Time: 2025-06-07T20:26:50.879872Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.002203  Lock_time: 0.000002 Rows_sent: 9  Rows_examined: 10003
+SET timestamp=1749328010;
+SELECT `id` FROM `posts` WHERE `user_id` = 75;
+# Time: 2025-06-07T20:26:50.899172Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018938  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100004
+SET timestamp=1749328010;
+SELECT COUNT(*) AS count FROM `comments` WHERE `post_id` IN (465,847,2738,3358,3682,3766,4659,6968,7358);
+# Time: 2025-06-07T20:26:50.974198Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.024285  Lock_time: 0.000002 Rows_sent: 10003  Rows_examined: 20006
+SET timestamp=1749328010;
+SELECT `id`, `user_id`, `body`, `created_at`, `mime` FROM `posts` ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:51.030084Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018369  Lock_time: 0.000003 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328011;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10025;
+# Time: 2025-06-07T20:26:51.086302Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.055588  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100005
+SET timestamp=1749328011;
+SELECT * FROM `comments` WHERE `post_id` = 10025 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:51.107043Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019416  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328011;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10024;
+# Time: 2025-06-07T20:26:51.162209Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054550  Lock_time: 0.000003 Rows_sent: 0  Rows_examined: 100005
+SET timestamp=1749328011;
+SELECT * FROM `comments` WHERE `post_id` = 10024 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:51.182264Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018797  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328011;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10023;
+# Time: 2025-06-07T20:26:51.242395Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.059586  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100005
+SET timestamp=1749328011;
+SELECT * FROM `comments` WHERE `post_id` = 10023 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:51.262519Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019221  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328011;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10000;
+# Time: 2025-06-07T20:26:51.324315Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.061269  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328011;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:51.346110Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019378  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328011;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9999;
+# Time: 2025-06-07T20:26:51.400607Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054110  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328011;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:51.421648Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018654  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328011;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9998;
+# Time: 2025-06-07T20:26:51.475087Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053002  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328011;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:51.495458Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018026  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328011;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9997;
+# Time: 2025-06-07T20:26:51.548002Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052131  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328011;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:51.568476Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018076  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328011;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9996;
+# Time: 2025-06-07T20:26:51.620806Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051926  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328011;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:51.641188Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018122  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328011;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9995;
+# Time: 2025-06-07T20:26:51.692171Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050574  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328011;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:51.712156Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017766  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328011;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9994;
+# Time: 2025-06-07T20:26:51.763060Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050463  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328011;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:51.782921Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017634  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328011;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9993;
+# Time: 2025-06-07T20:26:51.833424Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050117  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328011;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:51.853243Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017602  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328011;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9992;
+# Time: 2025-06-07T20:26:51.904099Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050447  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328011;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:51.924088Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017728  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328011;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9991;
+# Time: 2025-06-07T20:26:51.975026Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050521  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328011;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:51.994940Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017736  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328011;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9990;
+# Time: 2025-06-07T20:26:52.046220Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050835  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328011;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:52.066141Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017647  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328012;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9989;
+# Time: 2025-06-07T20:26:52.116784Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050263  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328012;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:52.136773Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017679  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328012;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9988;
+# Time: 2025-06-07T20:26:52.187241Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049960  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328012;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:52.207140Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017584  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328012;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9987;
+# Time: 2025-06-07T20:26:52.257103Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049568  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328012;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:52.276416Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017017  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328012;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9986;
+# Time: 2025-06-07T20:26:52.325302Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.048490  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328012;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:52.344397Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017031  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328012;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9985;
+# Time: 2025-06-07T20:26:52.394080Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049291  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328012;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:52.414013Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017633  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328012;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9984;
+# Time: 2025-06-07T20:26:52.464412Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050016  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328012;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:52.484346Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017707  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328012;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9983;
+# Time: 2025-06-07T20:26:52.535222Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050529  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328012;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:52.555055Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017575  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328012;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9982;
+# Time: 2025-06-07T20:26:52.605079Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049585  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328012;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:52.648264Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.024941  Lock_time: 0.000003 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328012;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 7762;
+# Time: 2025-06-07T20:26:52.703127Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054355  Lock_time: 0.000003 Rows_sent: 11  Rows_examined: 100016
+SET timestamp=1749328012;
+SELECT * FROM `comments` WHERE `post_id` = 7762 ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:52.767498Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.010416  Lock_time: 0.000039 Rows_sent: 6  Rows_examined: 10009
+SET timestamp=1749328012;
+SELECT `id`, `user_id`, `body`, `mime`, `created_at` FROM `posts` WHERE `user_id` = 476 ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:52.789260Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.021080  Lock_time: 0.000003 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328012;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9979;
+# Time: 2025-06-07T20:26:52.847254Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.057488  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328012;
+SELECT * FROM `comments` WHERE `post_id` = 9979 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:52.870525Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.020034  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328012;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 6854;
+# Time: 2025-06-07T20:26:52.927529Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.056359  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328012;
+SELECT * FROM `comments` WHERE `post_id` = 6854 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:52.950160Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.020064  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328012;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 6778;
+# Time: 2025-06-07T20:26:53.004615Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053974  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328012;
+SELECT * FROM `comments` WHERE `post_id` = 6778 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:53.026299Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019220  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328013;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 4354;
+# Time: 2025-06-07T20:26:53.080707Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053944  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328013;
+SELECT * FROM `comments` WHERE `post_id` = 4354 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:53.101646Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018604  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328013;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 3239;
+# Time: 2025-06-07T20:26:53.155145Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052534  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328013;
+SELECT * FROM `comments` WHERE `post_id` = 3239 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:53.176580Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018987  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328013;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 301;
+# Time: 2025-06-07T20:26:53.229384Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052353  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328013;
+SELECT * FROM `comments` WHERE `post_id` = 301 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:53.250411Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018640  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328013;
+SELECT COUNT(*) AS count FROM `comments` WHERE `user_id` = 476;
+# Time: 2025-06-07T20:26:53.252957Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.002170  Lock_time: 0.000001 Rows_sent: 6  Rows_examined: 10003
+SET timestamp=1749328013;
+SELECT `id` FROM `posts` WHERE `user_id` = 476;
+# Time: 2025-06-07T20:26:53.272175Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018820  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328013;
+SELECT COUNT(*) AS count FROM `comments` WHERE `post_id` IN (301,3239,4354,6778,6854,9979);
+# Time: 2025-06-07T20:26:53.359940Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.021581  Lock_time: 0.000004 Rows_sent: 10003  Rows_examined: 20006
+SET timestamp=1749328013;
+SELECT `id`, `user_id`, `body`, `created_at`, `mime` FROM `posts` ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:53.410894Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019996  Lock_time: 0.000003 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328013;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10025;
+# Time: 2025-06-07T20:26:53.465822Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054414  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100005
+SET timestamp=1749328013;
+SELECT * FROM `comments` WHERE `post_id` = 10025 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:53.485744Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018756  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328013;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10024;
+# Time: 2025-06-07T20:26:53.539731Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053450  Lock_time: 0.000001 Rows_sent: 0  Rows_examined: 100005
+SET timestamp=1749328013;
+SELECT * FROM `comments` WHERE `post_id` = 10024 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:53.559203Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018314  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328013;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10023;
+# Time: 2025-06-07T20:26:53.612139Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052407  Lock_time: 0.000001 Rows_sent: 0  Rows_examined: 100005
+SET timestamp=1749328013;
+SELECT * FROM `comments` WHERE `post_id` = 10023 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:53.631785Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018647  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328013;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10000;
+# Time: 2025-06-07T20:26:53.684389Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052205  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328013;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:53.704861Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018129  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328013;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9999;
+# Time: 2025-06-07T20:26:53.755989Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050727  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328013;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:53.775873Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017572  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328013;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9998;
+# Time: 2025-06-07T20:26:53.826145Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049868  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328013;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:53.845949Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017637  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328013;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9997;
+# Time: 2025-06-07T20:26:53.896356Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050004  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328013;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:53.916296Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017746  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328013;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9996;
+# Time: 2025-06-07T20:26:53.967539Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050758  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328013;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:53.987582Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017709  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328013;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9995;
+# Time: 2025-06-07T20:26:54.042522Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054424  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328013;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:54.065696Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.020237  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328014;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9994;
+# Time: 2025-06-07T20:26:54.119891Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053596  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328014;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:54.141429Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019270  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328014;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9993;
+# Time: 2025-06-07T20:26:54.195240Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053339  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328014;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:54.216438Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018893  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328014;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9992;
+# Time: 2025-06-07T20:26:54.268918Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052068  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328014;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:54.289609Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018396  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328014;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9991;
+# Time: 2025-06-07T20:26:54.342488Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052401  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328014;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:54.362858Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018102  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328014;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9990;
+# Time: 2025-06-07T20:26:54.414033Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050766  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328014;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:54.434066Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017780  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328014;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9989;
+# Time: 2025-06-07T20:26:54.484715Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050194  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328014;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:54.504856Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017885  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328014;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9988;
+# Time: 2025-06-07T20:26:54.555338Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050090  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328014;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:54.575178Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017702  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328014;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9987;
+# Time: 2025-06-07T20:26:54.625845Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050258  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328014;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:54.645636Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017585  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328014;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9986;
+# Time: 2025-06-07T20:26:54.696619Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050597  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328014;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:54.716865Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017874  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328014;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9985;
+# Time: 2025-06-07T20:26:54.768678Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051468  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328014;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:54.790336Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019023  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328014;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9984;
+# Time: 2025-06-07T20:26:54.850164Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.059296  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328014;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:54.871319Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018733  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328014;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9983;
+# Time: 2025-06-07T20:26:54.925195Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053414  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328014;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:54.946491Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018837  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328014;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9982;
+# Time: 2025-06-07T20:26:54.999529Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052592  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328014;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:55.036443Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.024020  Lock_time: 0.000004 Rows_sent: 10003  Rows_examined: 20006
+SET timestamp=1749328015;
+SELECT `id`, `user_id`, `body`, `created_at`, `mime` FROM `posts` ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:55.080998Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019103  Lock_time: 0.000003 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328015;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10025;
+# Time: 2025-06-07T20:26:55.135922Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054384  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100005
+SET timestamp=1749328015;
+SELECT * FROM `comments` WHERE `post_id` = 10025 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:55.155452Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018520  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328015;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10024;
+# Time: 2025-06-07T20:26:55.207533Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051656  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100005
+SET timestamp=1749328015;
+SELECT * FROM `comments` WHERE `post_id` = 10024 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:55.226649Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018117  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328015;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10023;
+# Time: 2025-06-07T20:26:55.278743Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051665  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100005
+SET timestamp=1749328015;
+SELECT * FROM `comments` WHERE `post_id` = 10023 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:55.298071Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018306  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328015;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10000;
+# Time: 2025-06-07T20:26:55.348794Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050284  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328015;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:55.368565Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017542  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328015;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9999;
+# Time: 2025-06-07T20:26:55.419940Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050968  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328015;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:55.439900Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017636  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328015;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9998;
+# Time: 2025-06-07T20:26:55.490626Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050264  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328015;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:55.510801Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018052  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328015;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9997;
+# Time: 2025-06-07T20:26:55.561591Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050378  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328015;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:55.581234Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017507  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328015;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9996;
+# Time: 2025-06-07T20:26:55.631643Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050031  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328015;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:55.651593Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017770  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328015;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9995;
+# Time: 2025-06-07T20:26:55.702098Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050132  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328015;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:55.721935Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017653  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328015;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9994;
+# Time: 2025-06-07T20:26:55.772539Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050138  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328015;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:55.792331Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017555  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328015;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9993;
+# Time: 2025-06-07T20:26:55.843083Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050357  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328015;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:55.862330Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017147  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328015;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9992;
+# Time: 2025-06-07T20:26:55.911505Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.048757  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328015;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:55.930649Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.016999  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328015;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9991;
+# Time: 2025-06-07T20:26:55.981255Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050231  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328015;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:56.001581Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017717  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328015;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9990;
+# Time: 2025-06-07T20:26:56.052209Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050177  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328016;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:56.072443Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018066  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328016;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9989;
+# Time: 2025-06-07T20:26:56.123021Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050187  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328016;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:56.143826Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018650  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328016;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9988;
+# Time: 2025-06-07T20:26:56.194068Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049760  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328016;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:56.213730Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017484  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328016;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9987;
+# Time: 2025-06-07T20:26:56.262961Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.048768  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328016;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:56.283076Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017913  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328016;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9986;
+# Time: 2025-06-07T20:26:56.332418Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.048924  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328016;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:56.351702Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017103  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328016;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9985;
+# Time: 2025-06-07T20:26:56.401349Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049266  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328016;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:56.421442Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017723  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328016;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9984;
+# Time: 2025-06-07T20:26:56.472237Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050349  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328016;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:56.492062Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017631  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328016;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9983;
+# Time: 2025-06-07T20:26:56.542642Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050192  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328016;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:56.562909Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017664  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328016;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9982;
+# Time: 2025-06-07T20:26:56.614612Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051299  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328016;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:56.652177Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.020773  Lock_time: 0.000002 Rows_sent: 10003  Rows_examined: 20006
+SET timestamp=1749328016;
+SELECT `id`, `user_id`, `body`, `created_at`, `mime` FROM `posts` ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:56.693566Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018272  Lock_time: 0.000003 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328016;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10025;
+# Time: 2025-06-07T20:26:56.746969Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052858  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100005
+SET timestamp=1749328016;
+SELECT * FROM `comments` WHERE `post_id` = 10025 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:56.766550Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018364  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328016;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10024;
+# Time: 2025-06-07T20:26:56.820410Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053276  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100005
+SET timestamp=1749328016;
+SELECT * FROM `comments` WHERE `post_id` = 10024 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:56.840473Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019217  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328016;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10023;
+# Time: 2025-06-07T20:26:56.909547Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.068533  Lock_time: 0.000003 Rows_sent: 0  Rows_examined: 100005
+SET timestamp=1749328016;
+SELECT * FROM `comments` WHERE `post_id` = 10023 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:56.934028Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.023430  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328016;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10000;
+# Time: 2025-06-07T20:26:56.991331Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.056751  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328016;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:57.014188Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.020321  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328016;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9999;
+# Time: 2025-06-07T20:26:57.070510Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.055794  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328017;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:57.092663Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019074  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328017;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9998;
+# Time: 2025-06-07T20:26:57.146929Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053726  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328017;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:57.167886Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018569  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328017;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9997;
+# Time: 2025-06-07T20:26:57.220186Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051890  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328017;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:57.241109Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018438  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328017;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9996;
+# Time: 2025-06-07T20:26:57.294639Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053102  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328017;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:57.315404Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018258  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328017;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9995;
+# Time: 2025-06-07T20:26:57.368899Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052997  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328017;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:57.389976Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018722  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328017;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9994;
+# Time: 2025-06-07T20:26:57.441911Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051447  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328017;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:57.461841Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017698  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328017;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9993;
+# Time: 2025-06-07T20:26:57.513989Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051792  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328017;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:57.534508Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018164  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328017;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9992;
+# Time: 2025-06-07T20:26:57.586354Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051428  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328017;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:57.606950Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018382  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328017;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9991;
+# Time: 2025-06-07T20:26:57.659392Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051949  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328017;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:57.679760Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018085  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328017;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9990;
+# Time: 2025-06-07T20:26:57.730563Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050388  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328017;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:57.751078Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017950  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328017;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9989;
+# Time: 2025-06-07T20:26:57.801763Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050260  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328017;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:57.821460Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017531  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328017;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9988;
+# Time: 2025-06-07T20:26:57.872383Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050520  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328017;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:57.892174Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017600  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328017;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9987;
+# Time: 2025-06-07T20:26:57.943131Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050567  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328017;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:57.963233Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017842  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328017;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9986;
+# Time: 2025-06-07T20:26:58.014752Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050386  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328017;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:58.036061Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017670  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328018;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9985;
+# Time: 2025-06-07T20:26:58.087102Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050641  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328018;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:58.107043Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017696  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328018;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9984;
+# Time: 2025-06-07T20:26:58.159082Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051581  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328018;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:58.178997Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017620  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328018;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9983;
+# Time: 2025-06-07T20:26:58.229412Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049995  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328018;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:58.249486Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017649  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328018;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9982;
+# Time: 2025-06-07T20:26:58.300211Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050240  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328018;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:58.368595Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.012968  Lock_time: 0.000004 Rows_sent: 7  Rows_examined: 10011
+SET timestamp=1749328018;
+SELECT `id`, `user_id`, `body`, `mime`, `created_at` FROM `posts` WHERE `user_id` = 603 ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:58.388882Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019632  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328018;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9872;
+# Time: 2025-06-07T20:26:58.444678Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.055231  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328018;
+SELECT * FROM `comments` WHERE `post_id` = 9872 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:58.466005Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018935  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328018;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 8070;
+# Time: 2025-06-07T20:26:58.520494Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054016  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328018;
+SELECT * FROM `comments` WHERE `post_id` = 8070 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:58.542021Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019154  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328018;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 7028;
+# Time: 2025-06-07T20:26:58.595251Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052812  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328018;
+SELECT * FROM `comments` WHERE `post_id` = 7028 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:58.615957Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018404  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328018;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 7001;
+# Time: 2025-06-07T20:26:58.668716Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052365  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328018;
+SELECT * FROM `comments` WHERE `post_id` = 7001 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:58.689633Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018571  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328018;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 6825;
+# Time: 2025-06-07T20:26:58.741842Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051748  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328018;
+SELECT * FROM `comments` WHERE `post_id` = 6825 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:58.762573Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018449  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328018;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 6486;
+# Time: 2025-06-07T20:26:58.813998Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050931  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328018;
+SELECT * FROM `comments` WHERE `post_id` = 6486 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:58.834494Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018110  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328018;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 5499;
+# Time: 2025-06-07T20:26:58.885888Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050998  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328018;
+SELECT * FROM `comments` WHERE `post_id` = 5499 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:58.906951Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018111  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328018;
+SELECT COUNT(*) AS count FROM `comments` WHERE `user_id` = 603;
+# Time: 2025-06-07T20:26:58.909615Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.002215  Lock_time: 0.000002 Rows_sent: 7  Rows_examined: 10004
+SET timestamp=1749328018;
+SELECT `id` FROM `posts` WHERE `user_id` = 603;
+# Time: 2025-06-07T20:26:58.928372Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018379  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328018;
+SELECT COUNT(*) AS count FROM `comments` WHERE `post_id` IN (5499,6486,6825,7001,7028,8070,9872);
+# Time: 2025-06-07T20:26:58.979245Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.026882  Lock_time: 0.000003 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328018;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10026;
+# Time: 2025-06-07T20:26:59.052105Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.072319  Lock_time: 0.000003 Rows_sent: 0  Rows_examined: 100005
+SET timestamp=1749328018;
+SELECT * FROM `comments` WHERE `post_id` = 10026 ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:59.124747Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.033995  Lock_time: 0.000005 Rows_sent: 10004  Rows_examined: 20008
+SET timestamp=1749328019;
+SELECT `id`, `user_id`, `body`, `created_at`, `mime` FROM `posts` ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:26:59.180362Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.020143  Lock_time: 0.000003 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328019;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10026;
+# Time: 2025-06-07T20:26:59.238737Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.057754  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100005
+SET timestamp=1749328019;
+SELECT * FROM `comments` WHERE `post_id` = 10026 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:59.259798Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019994  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328019;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10025;
+# Time: 2025-06-07T20:26:59.316254Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.055826  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100005
+SET timestamp=1749328019;
+SELECT * FROM `comments` WHERE `post_id` = 10025 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:59.336938Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019431  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328019;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10024;
+# Time: 2025-06-07T20:26:59.391805Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054305  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100005
+SET timestamp=1749328019;
+SELECT * FROM `comments` WHERE `post_id` = 10024 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:59.411856Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018833  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328019;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10023;
+# Time: 2025-06-07T20:26:59.467240Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054309  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100005
+SET timestamp=1749328019;
+SELECT * FROM `comments` WHERE `post_id` = 10023 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:59.486698Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018257  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328019;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10000;
+# Time: 2025-06-07T20:26:59.539567Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052329  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328019;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:59.560765Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018589  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328019;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9999;
+# Time: 2025-06-07T20:26:59.616427Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.055150  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328019;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:59.639261Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.020003  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328019;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9998;
+# Time: 2025-06-07T20:26:59.696169Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.056323  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328019;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:59.718710Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019370  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328019;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9997;
+# Time: 2025-06-07T20:26:59.774057Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054851  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328019;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:59.795280Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018826  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328019;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9996;
+# Time: 2025-06-07T20:26:59.849446Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053576  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328019;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:59.869965Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018165  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328019;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9995;
+# Time: 2025-06-07T20:26:59.922390Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052019  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328019;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:26:59.942819Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018099  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328019;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9994;
+# Time: 2025-06-07T20:26:59.994896Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051652  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328019;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:00.017101Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019929  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328019;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9993;
+# Time: 2025-06-07T20:27:00.069563Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051930  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328020;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:00.090077Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018266  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328020;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9992;
+# Time: 2025-06-07T20:27:00.141479Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050986  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328020;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:00.161249Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017561  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328020;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9991;
+# Time: 2025-06-07T20:27:00.212186Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050451  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328020;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:00.232705Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017637  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328020;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9990;
+# Time: 2025-06-07T20:27:00.283634Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050437  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328020;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:00.304280Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017749  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328020;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9989;
+# Time: 2025-06-07T20:27:00.355682Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050895  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328020;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:00.375690Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017610  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328020;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9988;
+# Time: 2025-06-07T20:27:00.427813Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051640  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328020;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:00.448200Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017520  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328020;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9987;
+# Time: 2025-06-07T20:27:00.499014Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050333  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328020;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:00.519365Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017523  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328020;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9986;
+# Time: 2025-06-07T20:27:00.568736Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.048856  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328020;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:00.588718Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017108  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328020;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9985;
+# Time: 2025-06-07T20:27:00.639601Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050400  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328020;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:00.660277Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017809  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328020;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9984;
+# Time: 2025-06-07T20:27:00.711636Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050857  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328020;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:00.731810Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017907  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100005
+SET timestamp=1749328020;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9983;
+# Time: 2025-06-07T20:27:00.782426Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050207  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100008
+SET timestamp=1749328020;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:00.848680Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019101  Lock_time: 0.000003 Rows_sent: 10004  Rows_examined: 20008
+SET timestamp=1749328020;
+SELECT `id`, `user_id`, `body`, `created_at`, `mime` FROM `posts` ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:27:00.893296Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018835  Lock_time: 0.000004 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328020;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10026;
+# Time: 2025-06-07T20:27:00.947218Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053384  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100006
+SET timestamp=1749328020;
+SELECT * FROM `comments` WHERE `post_id` = 10026 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:00.966850Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018578  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328020;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10025;
+# Time: 2025-06-07T20:27:01.018988Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051726  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100006
+SET timestamp=1749328020;
+SELECT * FROM `comments` WHERE `post_id` = 10025 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:01.038102Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018119  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328021;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10024;
+# Time: 2025-06-07T20:27:01.095759Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.057209  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100006
+SET timestamp=1749328021;
+SELECT * FROM `comments` WHERE `post_id` = 10024 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:01.116651Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019587  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328021;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10023;
+# Time: 2025-06-07T20:27:01.172898Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.055666  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100006
+SET timestamp=1749328021;
+SELECT * FROM `comments` WHERE `post_id` = 10023 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:01.193585Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019634  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328021;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10000;
+# Time: 2025-06-07T20:27:01.247712Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053663  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328021;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:01.269361Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019226  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328021;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9999;
+# Time: 2025-06-07T20:27:01.322018Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052243  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328021;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:01.342601Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018268  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328021;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9998;
+# Time: 2025-06-07T20:27:01.394736Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051712  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328021;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:01.415224Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018053  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328021;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9997;
+# Time: 2025-06-07T20:27:01.467914Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052291  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328021;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:01.487875Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017658  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328021;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9996;
+# Time: 2025-06-07T20:27:01.539250Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050952  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328021;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:01.559122Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017651  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328021;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9995;
+# Time: 2025-06-07T20:27:01.610477Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050883  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328021;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:01.630337Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017562  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328021;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9994;
+# Time: 2025-06-07T20:27:01.680797Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050043  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328021;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:01.700915Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017945  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328021;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9993;
+# Time: 2025-06-07T20:27:01.751735Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050419  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328021;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:01.771529Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017559  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328021;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9992;
+# Time: 2025-06-07T20:27:01.823280Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051342  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328021;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:01.843464Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017922  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328021;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9991;
+# Time: 2025-06-07T20:27:01.894569Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050699  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328021;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:01.914457Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017612  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328021;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9990;
+# Time: 2025-06-07T20:27:01.965205Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050358  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328021;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:01.985053Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017636  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328021;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9989;
+# Time: 2025-06-07T20:27:02.035929Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050471  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328021;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:02.055763Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017513  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328022;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9988;
+# Time: 2025-06-07T20:27:02.107575Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051417  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328022;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:02.127416Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017547  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328022;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9987;
+# Time: 2025-06-07T20:27:02.177943Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050181  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328022;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:02.197675Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017523  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328022;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9986;
+# Time: 2025-06-07T20:27:02.248123Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050046  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328022;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:02.267865Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017525  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328022;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9985;
+# Time: 2025-06-07T20:27:02.318641Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050388  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328022;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:02.339335Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017997  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328022;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9984;
+# Time: 2025-06-07T20:27:02.393843Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054056  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328022;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:02.415491Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018736  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328022;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9983;
+# Time: 2025-06-07T20:27:02.469944Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053921  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328022;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:02.527159Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.021198  Lock_time: 0.000004 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328022;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9872;
+# Time: 2025-06-07T20:27:02.582309Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054593  Lock_time: 0.000001 Rows_sent: 9  Rows_examined: 100015
+SET timestamp=1749328022;
+SELECT * FROM `comments` WHERE `post_id` = 9872 ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:27:02.618001Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019360  Lock_time: 0.000004 Rows_sent: 10004  Rows_examined: 20008
+SET timestamp=1749328022;
+SELECT `id`, `user_id`, `body`, `created_at`, `mime` FROM `posts` ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:27:02.662009Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019237  Lock_time: 0.000003 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328022;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10026;
+# Time: 2025-06-07T20:27:02.714688Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052165  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100006
+SET timestamp=1749328022;
+SELECT * FROM `comments` WHERE `post_id` = 10026 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:02.734554Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018700  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328022;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10025;
+# Time: 2025-06-07T20:27:02.787810Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052734  Lock_time: 0.000001 Rows_sent: 0  Rows_examined: 100006
+SET timestamp=1749328022;
+SELECT * FROM `comments` WHERE `post_id` = 10025 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:02.806971Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018182  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328022;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10024;
+# Time: 2025-06-07T20:27:02.857653Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050292  Lock_time: 0.000001 Rows_sent: 0  Rows_examined: 100006
+SET timestamp=1749328022;
+SELECT * FROM `comments` WHERE `post_id` = 10024 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:02.876160Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017557  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328022;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10023;
+# Time: 2025-06-07T20:27:02.927512Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050962  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100006
+SET timestamp=1749328022;
+SELECT * FROM `comments` WHERE `post_id` = 10023 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:02.946100Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017600  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328022;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10000;
+# Time: 2025-06-07T20:27:02.996592Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050104  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328022;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:03.016330Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017526  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328022;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9999;
+# Time: 2025-06-07T20:27:03.066736Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050005  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328023;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:03.086597Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017651  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328023;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9998;
+# Time: 2025-06-07T20:27:03.137555Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050510  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328023;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:03.159449Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019480  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328023;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9997;
+# Time: 2025-06-07T20:27:03.216041Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.056092  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328023;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:03.237320Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018842  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328023;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9996;
+# Time: 2025-06-07T20:27:03.291364Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053626  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328023;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:03.312603Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018937  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328023;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9995;
+# Time: 2025-06-07T20:27:03.366217Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053202  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328023;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:03.386761Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018118  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328023;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9994;
+# Time: 2025-06-07T20:27:03.438876Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051662  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328023;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:03.459317Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018138  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328023;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9993;
+# Time: 2025-06-07T20:27:03.511961Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052251  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328023;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:03.532341Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018127  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328023;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9992;
+# Time: 2025-06-07T20:27:03.582754Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050010  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328023;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:03.602663Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017724  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328023;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9991;
+# Time: 2025-06-07T20:27:03.653582Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050463  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328023;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:03.673435Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017601  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328023;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9990;
+# Time: 2025-06-07T20:27:03.724190Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050352  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328023;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:03.744407Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017567  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328023;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9989;
+# Time: 2025-06-07T20:27:03.794930Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050134  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328023;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:03.814834Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017633  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328023;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9988;
+# Time: 2025-06-07T20:27:03.865846Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050590  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328023;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:03.885611Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017553  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328023;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9987;
+# Time: 2025-06-07T20:27:03.936360Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050353  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328023;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:03.956263Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017685  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328023;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9986;
+# Time: 2025-06-07T20:27:04.007135Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050448  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328023;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:04.026844Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017594  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328024;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9985;
+# Time: 2025-06-07T20:27:04.077223Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049995  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328024;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:04.097037Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017579  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328024;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9984;
+# Time: 2025-06-07T20:27:04.149853Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052348  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328024;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:04.170043Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017869  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328024;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9983;
+# Time: 2025-06-07T20:27:04.220531Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050058  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328024;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:04.248612Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018063  Lock_time: 0.000004 Rows_sent: 9988  Rows_examined: 19992
+SET timestamp=1749328024;
+SELECT `id`, `user_id`, `body`, `mime`, `created_at` FROM `posts` WHERE `created_at` <= '2016-01-02 02:46:28' ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:27:04.285786Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017954  Lock_time: 0.000003 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328024;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9988;
+# Time: 2025-06-07T20:27:04.337472Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051163  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328024;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:04.358079Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017800  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328024;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9987;
+# Time: 2025-06-07T20:27:04.409491Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050834  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328024;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:04.430105Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017725  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328024;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9986;
+# Time: 2025-06-07T20:27:04.481132Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050509  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328024;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:04.501683Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017715  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328024;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9985;
+# Time: 2025-06-07T20:27:04.553840Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051663  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328024;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:04.573799Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017607  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328024;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9984;
+# Time: 2025-06-07T20:27:04.624645Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050431  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328024;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:04.644798Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017906  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328024;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9983;
+# Time: 2025-06-07T20:27:04.695798Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050606  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328024;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:04.716097Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017805  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328024;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9982;
+# Time: 2025-06-07T20:27:04.766421Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049921  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328024;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:04.786589Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017984  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328024;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9981;
+# Time: 2025-06-07T20:27:04.838163Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050519  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328024;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:04.858063Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017622  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328024;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9980;
+# Time: 2025-06-07T20:27:04.907686Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049238  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328024;
+SELECT * FROM `comments` WHERE `post_id` = 9980 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:04.927081Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017279  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328024;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9979;
+# Time: 2025-06-07T20:27:04.976600Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049121  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328024;
+SELECT * FROM `comments` WHERE `post_id` = 9979 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:04.996511Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017751  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328024;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9978;
+# Time: 2025-06-07T20:27:05.047038Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050139  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328024;
+SELECT * FROM `comments` WHERE `post_id` = 9978 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:05.066880Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017591  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328025;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9977;
+# Time: 2025-06-07T20:27:05.119195Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051941  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328025;
+SELECT * FROM `comments` WHERE `post_id` = 9977 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:05.140718Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018801  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328025;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9976;
+# Time: 2025-06-07T20:27:05.195328Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054055  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328025;
+SELECT * FROM `comments` WHERE `post_id` = 9976 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:05.216951Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018685  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328025;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9975;
+# Time: 2025-06-07T20:27:05.272680Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.055211  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328025;
+SELECT * FROM `comments` WHERE `post_id` = 9975 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:05.296139Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.020346  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328025;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9974;
+# Time: 2025-06-07T20:27:05.353169Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.056465  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328025;
+SELECT * FROM `comments` WHERE `post_id` = 9974 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:05.375705Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019407  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328025;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9973;
+# Time: 2025-06-07T20:27:05.430712Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054370  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328025;
+SELECT * FROM `comments` WHERE `post_id` = 9973 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:05.452629Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018930  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328025;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9972;
+# Time: 2025-06-07T20:27:05.507483Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054273  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328025;
+SELECT * FROM `comments` WHERE `post_id` = 9972 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:05.529416Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018935  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328025;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9971;
+# Time: 2025-06-07T20:27:05.582625Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052646  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328025;
+SELECT * FROM `comments` WHERE `post_id` = 9971 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:05.603363Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018244  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328025;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9970;
+# Time: 2025-06-07T20:27:05.656340Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052484  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328025;
+SELECT * FROM `comments` WHERE `post_id` = 9970 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:05.677316Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018367  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328025;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9969;
+# Time: 2025-06-07T20:27:05.729576Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051756  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328025;
+SELECT * FROM `comments` WHERE `post_id` = 9969 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:05.750282Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018442  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328025;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9968;
+# Time: 2025-06-07T20:27:05.802713Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052011  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328025;
+SELECT * FROM `comments` WHERE `post_id` = 9968 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:05.823164Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018156  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328025;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9967;
+# Time: 2025-06-07T20:27:05.876498Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052820  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328025;
+SELECT * FROM `comments` WHERE `post_id` = 9967 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:05.955094Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019339  Lock_time: 0.000003 Rows_sent: 9987  Rows_examined: 19991
+SET timestamp=1749328025;
+SELECT `id`, `user_id`, `body`, `mime`, `created_at` FROM `posts` WHERE `created_at` <= '2016-01-02 02:46:27' ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:27:06.015951Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.032911  Lock_time: 0.000005 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328025;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9987;
+# Time: 2025-06-07T20:27:06.082811Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.066139  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328026;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:06.107121Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.021345  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328026;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9986;
+# Time: 2025-06-07T20:27:06.166301Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.058575  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328026;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:06.190321Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.020726  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328026;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9985;
+# Time: 2025-06-07T20:27:06.250976Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.060017  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328026;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:06.273888Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019679  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328026;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9984;
+# Time: 2025-06-07T20:27:06.331364Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.056866  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328026;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:06.354418Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019893  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328026;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9983;
+# Time: 2025-06-07T20:27:06.411857Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.056809  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328026;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:06.433465Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019153  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328026;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9982;
+# Time: 2025-06-07T20:27:06.488369Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054370  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328026;
+SELECT * FROM `comments` WHERE `post_id` = 9982 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:06.509636Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018809  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328026;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9981;
+# Time: 2025-06-07T20:27:06.562747Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052737  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328026;
+SELECT * FROM `comments` WHERE `post_id` = 9981 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:06.583359Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018199  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328026;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9980;
+# Time: 2025-06-07T20:27:06.636816Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053058  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328026;
+SELECT * FROM `comments` WHERE `post_id` = 9980 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:06.658460Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019374  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328026;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9979;
+# Time: 2025-06-07T20:27:06.712234Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053320  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328026;
+SELECT * FROM `comments` WHERE `post_id` = 9979 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:06.735405Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019830  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328026;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9978;
+# Time: 2025-06-07T20:27:06.790379Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054497  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328026;
+SELECT * FROM `comments` WHERE `post_id` = 9978 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:06.812177Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019376  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328026;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9977;
+# Time: 2025-06-07T20:27:06.866932Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054111  Lock_time: 0.000004 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328026;
+SELECT * FROM `comments` WHERE `post_id` = 9977 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:06.888047Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018094  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328026;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9976;
+# Time: 2025-06-07T20:27:06.941329Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052746  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328026;
+SELECT * FROM `comments` WHERE `post_id` = 9976 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:06.962007Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018289  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328026;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9975;
+# Time: 2025-06-07T20:27:07.015217Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052598  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328026;
+SELECT * FROM `comments` WHERE `post_id` = 9975 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:07.036540Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018680  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328027;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9974;
+# Time: 2025-06-07T20:27:07.089293Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052305  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328027;
+SELECT * FROM `comments` WHERE `post_id` = 9974 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:07.110804Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019063  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328027;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9973;
+# Time: 2025-06-07T20:27:07.163964Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052646  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328027;
+SELECT * FROM `comments` WHERE `post_id` = 9973 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:07.184746Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018311  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328027;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9972;
+# Time: 2025-06-07T20:27:07.238280Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053065  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328027;
+SELECT * FROM `comments` WHERE `post_id` = 9972 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:07.259394Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018375  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328027;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9971;
+# Time: 2025-06-07T20:27:07.311720Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051832  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328027;
+SELECT * FROM `comments` WHERE `post_id` = 9971 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:07.333186Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018609  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328027;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9970;
+# Time: 2025-06-07T20:27:07.392265Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.058466  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328027;
+SELECT * FROM `comments` WHERE `post_id` = 9970 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:07.414880Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019441  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328027;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9969;
+# Time: 2025-06-07T20:27:07.471705Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.056229  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328027;
+SELECT * FROM `comments` WHERE `post_id` = 9969 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:07.494284Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019638  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328027;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9968;
+# Time: 2025-06-07T20:27:07.549331Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054465  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328027;
+SELECT * FROM `comments` WHERE `post_id` = 9968 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:07.570736Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018963  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328027;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9967;
+# Time: 2025-06-07T20:27:07.624885Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053618  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328027;
+SELECT * FROM `comments` WHERE `post_id` = 9967 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:07.646468Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019132  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328027;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9966;
+# Time: 2025-06-07T20:27:07.701267Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054185  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328027;
+SELECT * FROM `comments` WHERE `post_id` = 9966 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:07.750045Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.021704  Lock_time: 0.000002 Rows_sent: 10004  Rows_examined: 20008
+SET timestamp=1749328027;
+SELECT `id`, `user_id`, `body`, `created_at`, `mime` FROM `posts` ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:27:07.797339Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.020285  Lock_time: 0.000003 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328027;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10026;
+# Time: 2025-06-07T20:27:07.853612Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.055655  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100006
+SET timestamp=1749328027;
+SELECT * FROM `comments` WHERE `post_id` = 10026 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:07.875291Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.020170  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328027;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10025;
+# Time: 2025-06-07T20:27:07.933783Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.058028  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100006
+SET timestamp=1749328027;
+SELECT * FROM `comments` WHERE `post_id` = 10025 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:07.955208Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.020314  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328027;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10024;
+# Time: 2025-06-07T20:27:08.012487Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.056800  Lock_time: 0.000003 Rows_sent: 0  Rows_examined: 100006
+SET timestamp=1749328027;
+SELECT * FROM `comments` WHERE `post_id` = 10024 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:08.033174Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019608  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328028;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10023;
+# Time: 2025-06-07T20:27:08.088881Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.055282  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100006
+SET timestamp=1749328028;
+SELECT * FROM `comments` WHERE `post_id` = 10023 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:08.108544Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018645  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328028;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10000;
+# Time: 2025-06-07T20:27:08.164070Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.055132  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328028;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:08.185391Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018802  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328028;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9999;
+# Time: 2025-06-07T20:27:08.239769Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053809  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328028;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:08.260627Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018427  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328028;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9998;
+# Time: 2025-06-07T20:27:08.313050Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051809  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328028;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:08.333539Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018192  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328028;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9997;
+# Time: 2025-06-07T20:27:08.385875Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051861  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328028;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:08.406273Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018136  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328028;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9996;
+# Time: 2025-06-07T20:27:08.459250Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052565  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328028;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:08.479503Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017979  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328028;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9995;
+# Time: 2025-06-07T20:27:08.530186Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050313  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328028;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:08.549963Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017605  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328028;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9994;
+# Time: 2025-06-07T20:27:08.601004Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050630  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328028;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:08.621138Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017918  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328028;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9993;
+# Time: 2025-06-07T20:27:08.672045Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050489  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328028;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:08.692106Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017821  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328028;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9992;
+# Time: 2025-06-07T20:27:08.742701Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050145  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328028;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:08.762770Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017810  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328028;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9991;
+# Time: 2025-06-07T20:27:08.813642Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050467  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328028;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:08.833538Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017648  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328028;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9990;
+# Time: 2025-06-07T20:27:08.885305Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051375  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328028;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:08.905065Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017259  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328028;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9989;
+# Time: 2025-06-07T20:27:08.954192Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.048784  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328028;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:08.973910Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017077  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328028;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9988;
+# Time: 2025-06-07T20:27:09.024970Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050670  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328028;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:09.045112Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017809  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328029;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9987;
+# Time: 2025-06-07T20:27:09.096540Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050981  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328029;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:09.116809Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018009  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328029;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9986;
+# Time: 2025-06-07T20:27:09.167383Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050199  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328029;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:09.187120Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017556  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328029;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9985;
+# Time: 2025-06-07T20:27:09.237942Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050429  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328029;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:09.257670Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017500  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328029;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9984;
+# Time: 2025-06-07T20:27:09.307465Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.049457  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328029;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:09.326856Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017233  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328029;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9983;
+# Time: 2025-06-07T20:27:09.375928Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.048656  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328029;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:09.403712Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019033  Lock_time: 0.000002 Rows_sent: 10004  Rows_examined: 20008
+SET timestamp=1749328029;
+SELECT `id`, `user_id`, `body`, `created_at`, `mime` FROM `posts` ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:27:09.448030Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018857  Lock_time: 0.000003 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328029;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10026;
+# Time: 2025-06-07T20:27:09.513878Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.065237  Lock_time: 0.000004 Rows_sent: 0  Rows_examined: 100006
+SET timestamp=1749328029;
+SELECT * FROM `comments` WHERE `post_id` = 10026 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:09.534475Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019333  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328029;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10025;
+# Time: 2025-06-07T20:27:09.589132Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054119  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100006
+SET timestamp=1749328029;
+SELECT * FROM `comments` WHERE `post_id` = 10025 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:09.608997Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018625  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328029;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10024;
+# Time: 2025-06-07T20:27:09.661493Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051979  Lock_time: 0.000001 Rows_sent: 0  Rows_examined: 100006
+SET timestamp=1749328029;
+SELECT * FROM `comments` WHERE `post_id` = 10024 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:09.680559Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018106  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328029;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10023;
+# Time: 2025-06-07T20:27:09.733700Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052696  Lock_time: 0.000002 Rows_sent: 0  Rows_examined: 100006
+SET timestamp=1749328029;
+SELECT * FROM `comments` WHERE `post_id` = 10023 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:09.752848Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018116  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328029;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10000;
+# Time: 2025-06-07T20:27:09.804914Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051654  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328029;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:09.825045Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017756  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328029;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9999;
+# Time: 2025-06-07T20:27:09.875741Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050311  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328029;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:09.896224Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018277  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328029;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9998;
+# Time: 2025-06-07T20:27:09.947191Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050545  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328029;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:09.967082Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017652  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328029;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9997;
+# Time: 2025-06-07T20:27:10.018175Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050636  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328029;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:10.038041Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017617  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328030;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9996;
+# Time: 2025-06-07T20:27:10.089056Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050564  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328030;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:10.109714Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017761  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328030;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9995;
+# Time: 2025-06-07T20:27:10.162193Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051972  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328030;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:10.182304Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017767  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328030;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9994;
+# Time: 2025-06-07T20:27:10.233121Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050404  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328030;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:10.253631Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017609  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328030;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9993;
+# Time: 2025-06-07T20:27:10.304793Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050654  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328030;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:10.325567Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018397  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328030;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9992;
+# Time: 2025-06-07T20:27:10.376885Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050938  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328030;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:10.397511Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017799  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328030;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9991;
+# Time: 2025-06-07T20:27:10.449408Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051403  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328030;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:10.469307Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017559  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328030;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9990;
+# Time: 2025-06-07T20:27:10.520061Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050364  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328030;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:10.541015Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017936  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328030;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9989;
+# Time: 2025-06-07T20:27:10.591835Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050404  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328030;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:10.612590Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017952  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328030;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9988;
+# Time: 2025-06-07T20:27:10.670235Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.057052  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328030;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:10.696045Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.023242  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328030;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9987;
+# Time: 2025-06-07T20:27:10.751463Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054822  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328030;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:10.772431Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018529  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328030;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9986;
+# Time: 2025-06-07T20:27:10.824377Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051544  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328030;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:10.844878Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018129  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328030;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9985;
+# Time: 2025-06-07T20:27:10.897173Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051870  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328030;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:10.917742Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018263  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328030;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9984;
+# Time: 2025-06-07T20:27:10.968525Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050364  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328030;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:10.999486Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.028782  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328030;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9983;
+# Time: 2025-06-07T20:27:11.058874Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.058753  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328031;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:11.104749Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018854  Lock_time: 0.000004 Rows_sent: 10004  Rows_examined: 20008
+SET timestamp=1749328031;
+SELECT `id`, `user_id`, `body`, `created_at`, `mime` FROM `posts` ORDER BY `created_at` DESC;
+# Time: 2025-06-07T20:27:11.152893Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.020953  Lock_time: 0.000003 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328031;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10026;
+# Time: 2025-06-07T20:27:11.213398Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.059940  Lock_time: 0.000003 Rows_sent: 0  Rows_examined: 100006
+SET timestamp=1749328031;
+SELECT * FROM `comments` WHERE `post_id` = 10026 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:11.235745Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.021102  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328031;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10025;
+# Time: 2025-06-07T20:27:11.296672Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.060317  Lock_time: 0.000003 Rows_sent: 0  Rows_examined: 100006
+SET timestamp=1749328031;
+SELECT * FROM `comments` WHERE `post_id` = 10025 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:11.319030Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.021043  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328031;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10024;
+# Time: 2025-06-07T20:27:11.383497Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.063830  Lock_time: 0.000003 Rows_sent: 0  Rows_examined: 100006
+SET timestamp=1749328031;
+SELECT * FROM `comments` WHERE `post_id` = 10024 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:11.405831Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.021012  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328031;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10023;
+# Time: 2025-06-07T20:27:11.467732Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.061168  Lock_time: 0.000003 Rows_sent: 0  Rows_examined: 100006
+SET timestamp=1749328031;
+SELECT * FROM `comments` WHERE `post_id` = 10023 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:11.490031Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.020889  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328031;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 10000;
+# Time: 2025-06-07T20:27:11.560162Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.069518  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328031;
+SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:11.589697Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.025622  Lock_time: 0.000003 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328031;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9999;
+# Time: 2025-06-07T20:27:11.653138Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.062802  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328031;
+SELECT * FROM `comments` WHERE `post_id` = 9999 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:11.677817Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.021686  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328031;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9998;
+# Time: 2025-06-07T20:27:11.741817Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.063383  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328031;
+SELECT * FROM `comments` WHERE `post_id` = 9998 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:11.772863Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.027655  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328031;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9997;
+# Time: 2025-06-07T20:27:11.839504Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.066031  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328031;
+SELECT * FROM `comments` WHERE `post_id` = 9997 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:11.866888Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.022619  Lock_time: 0.000002 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328031;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9996;
+# Time: 2025-06-07T20:27:11.930855Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.063355  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328031;
+SELECT * FROM `comments` WHERE `post_id` = 9996 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:11.957698Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.023701  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328031;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9995;
+# Time: 2025-06-07T20:27:12.022520Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.064288  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328031;
+SELECT * FROM `comments` WHERE `post_id` = 9995 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:12.046597Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.020799  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328032;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9994;
+# Time: 2025-06-07T20:27:12.106496Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.059308  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328032;
+SELECT * FROM `comments` WHERE `post_id` = 9994 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:12.129859Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.020102  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328032;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9993;
+# Time: 2025-06-07T20:27:12.186390Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.055953  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328032;
+SELECT * FROM `comments` WHERE `post_id` = 9993 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:12.208097Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019223  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328032;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9992;
+# Time: 2025-06-07T20:27:12.262544Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.054025  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328032;
+SELECT * FROM `comments` WHERE `post_id` = 9992 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:12.283920Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018941  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328032;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9991;
+# Time: 2025-06-07T20:27:12.338037Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.053617  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328032;
+SELECT * FROM `comments` WHERE `post_id` = 9991 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:12.358598Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018199  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328032;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9990;
+# Time: 2025-06-07T20:27:12.411401Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.052318  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328032;
+SELECT * FROM `comments` WHERE `post_id` = 9990 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:12.431804Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018114  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328032;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9989;
+# Time: 2025-06-07T20:27:12.483640Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.051435  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328032;
+SELECT * FROM `comments` WHERE `post_id` = 9989 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:12.503935Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018034  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328032;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9988;
+# Time: 2025-06-07T20:27:12.554629Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050346  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328032;
+SELECT * FROM `comments` WHERE `post_id` = 9988 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:12.574479Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017576  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328032;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9987;
+# Time: 2025-06-07T20:27:12.624950Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050054  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328032;
+SELECT * FROM `comments` WHERE `post_id` = 9987 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:12.644892Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017688  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328032;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9986;
+# Time: 2025-06-07T20:27:12.695294Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050016  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328032;
+SELECT * FROM `comments` WHERE `post_id` = 9986 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:12.714943Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.017505  Lock_time: 0.000001 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328032;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9985;
+# Time: 2025-06-07T20:27:12.765993Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050629  Lock_time: 0.000002 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328032;
+SELECT * FROM `comments` WHERE `post_id` = 9985 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:12.787544Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.019304  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328032;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9984;
+# Time: 2025-06-07T20:27:12.838318Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050285  Lock_time: 0.000003 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328032;
+SELECT * FROM `comments` WHERE `post_id` = 9984 ORDER BY `created_at` DESC LIMIT 3;
+# Time: 2025-06-07T20:27:12.858870Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.018299  Lock_time: 0.000000 Rows_sent: 1  Rows_examined: 100006
+SET timestamp=1749328032;
+SELECT COUNT(*) AS `count` FROM `comments` WHERE `post_id` = 9983;
+# Time: 2025-06-07T20:27:12.909664Z
+# User@Host: root[root] @  [172.20.0.4]  Id:     8
+# Query_time: 0.050451  Lock_time: 0.000001 Rows_sent: 3  Rows_examined: 100009
+SET timestamp=1749328032;
+SELECT * FROM `comments` WHERE `post_id` = 9983 ORDER BY `created_at` DESC LIMIT 3;

--- a/sql/tuning.sql
+++ b/sql/tuning.sql
@@ -1,0 +1,18 @@
+-- tuning.sql
+
+-- Check if index 'idx_post_created' exists
+SET @index_exists := (
+  SELECT COUNT(*) FROM information_schema.statistics
+  WHERE table_schema = DATABASE()
+    AND table_name = 'comments'
+    AND index_name = 'idx_post_created'
+);
+
+-- Dynamically add the index only if it doesn't exist
+SET @sql := IF(@index_exists = 0,
+  'ALTER TABLE comments ADD INDEX idx_post_created (post_id, created_at DESC)',
+  'SELECT "Index already exists";');
+
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;


### PR DESCRIPTION
### before score
`{"pass":true,"score":421,"success":417,"fail":4,"messages":["リクエストがタイムアウトしました (POST /login)","リクエストがタイムアウトしました (POST /register)"]}`
### after score
`{"pass":true,"score":4172,"success":3575,"fail":0,"messages":[]}`
### description
commentsテーブルに複合インデックスを追加しました。
slow-report.txtにより、以下のクエリが主なボトルネックとなっていたので：
``SELECT * FROM `comments` WHERE `post_id` = 10000 ORDER BY `created_at` DESC LIMIT 3``
```
docker cp private-isu-mysql-1:/var/lib/mysql/d55d77457413-slow.log ./log/slow.log
pt-query-digest ./log/slow.log > ./log/slow-report.txt
``` 
[log/slow-report.txt](./log/slow-report.txt)
[log/slow.log](./log/slow.log)
